### PR TITLE
fix: Resolve Vercel Dynamic Server Error for pages using headers()

### DIFF
--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -2,6 +2,8 @@ import * as Admin from '@/features/admin/templates/index';
 import Template from '@/app/template';
 import { headers } from 'next/headers';
 
+export const dynamic = 'force-dynamic';
+
 export default async function AdminPage() {
   const incomingHeaders = await headers();
   const cookieHeader = incomingHeaders.get('cookie') || '';

--- a/app/(dashboards)/todo/page.tsx
+++ b/app/(dashboards)/todo/page.tsx
@@ -1,5 +1,8 @@
 import * as Todo from '@/features/todo/templates/index';
 import Template from '@/app/template';
+
+export const dynamic = 'force-dynamic';
+
 export default async function TodoPage() {
   return (
     <Template showHeader={true}>


### PR DESCRIPTION
## Summary
- Add `export const dynamic = 'force-dynamic'` to `/todo` and `/admin` pages
- Resolves Vercel build warning: "Route couldn't be rendered statically because it used `headers`"
- Maintains existing functionality while eliminating build warnings

## Test plan
- [x] Verify pages render correctly with dynamic rendering
- [x] Confirm no performance impact for authentication-required pages
- [x] Check Vercel build completes without Dynamic Server Error warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 管理ページとToDoページを動的レンダリングに切り替え、キャッシュを回避して常に最新データを表示。
  - 頻繁に更新される情報の一貫性が向上し、リアルタイム性が改善。初回表示時のパフォーマンスに影響する場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->