### PR TITLE
fix: サインアウト後に前ユーザーのキャッシュが表示される問題を修正 (close #81)

### DIFF
--- a/app/(dashboards)/loading.tsx
+++ b/app/(dashboards)/loading.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 export default function TodosLoading() {
   return (
     <div className="flex flex-col items-center justify-center p-8 min-h-screen">
-      <div className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+      <div
+        role="status"
+        aria-label="読み込み中"
+        className="w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"
+      ></div>
       <p className="mt-4 text-md text-gray-600">読み込み中...</p>
     </div>
   );

--- a/features/todo/components/elements/Error/ErrorDisplay.tsx
+++ b/features/todo/components/elements/Error/ErrorDisplay.tsx
@@ -39,7 +39,11 @@ export default function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
           mb: 2,
         }}
       >
-        <ErrorIcon aria-hidden="true" sx={{ fontSize: 40, color: '#fff' }} />
+        <ErrorIcon
+          data-testid="ErrorIcon"
+          aria-hidden="true"
+          sx={{ fontSize: 40, color: '#fff' }}
+        />
       </Paper>
       <Typography variant="h6" sx={{ mb: 1, fontWeight: 'medium' }}>
         エラーが発生しました

--- a/features/todo/components/elements/Error/ErrorDisplay.tsx
+++ b/features/todo/components/elements/Error/ErrorDisplay.tsx
@@ -39,10 +39,7 @@ export default function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
           mb: 2,
         }}
       >
-        <ErrorIcon
-          aria-label="errorIcon"
-          sx={{ fontSize: 40, color: '#fff' }}
-        />
+        <ErrorIcon aria-hidden="true" sx={{ fontSize: 40, color: '#fff' }} />
       </Paper>
       <Typography variant="h6" sx={{ mb: 1, fontWeight: 'medium' }}>
         エラーが発生しました

--- a/features/todo/templates/TodoWrapper.tsx
+++ b/features/todo/templates/TodoWrapper.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { TodoListProps } from '@/types/todos';
 import { StatusListProps } from '@/types/lists';
 import { Box } from '@mui/material';
 import PushContainer from '@/features/todo/components/PushContainer/PushContainer';
 import MainContainer from '@/features/todo/components/MainContainer/MainContainer';
 import { TodoProvider } from '@/features/todo/contexts/TodoContext';
-import useSWR, { SWRConfig, preload } from 'swr';
+import useSWR, { SWRConfig, preload, useSWRConfig } from 'swr';
 import TodosLoading from '@/app/(dashboards)/loading';
 import ErrorDisplay from '@/features/todo/components/elements/Error/ErrorDisplay';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -127,6 +127,21 @@ const TodoContent = (): React.ReactElement => {
     emulatorMode || (status === 'authenticated' && Boolean(sessionUser?.id));
 
   const [sessionGraceOver, setSessionGraceOver] = useState(false);
+  const { mutate: globalMutate } = useSWRConfig();
+  const prevUserIdRef = useRef<string | undefined>(undefined);
+
+  // ユーザーIDが変わった時（ログアウト・ユーザー切り替え）にSWRキャッシュをクリア
+  useEffect(() => {
+    const currentUserId = sessionUser?.id;
+    if (
+      prevUserIdRef.current !== undefined &&
+      prevUserIdRef.current !== currentUserId
+    ) {
+      void globalMutate(todosApiUrl, undefined, { revalidate: false });
+      void globalMutate(listsApiUrl, undefined, { revalidate: false });
+    }
+    prevUserIdRef.current = currentUserId;
+  }, [sessionUser?.id, globalMutate, todosApiUrl, listsApiUrl]);
 
   // セッション待機の設定
   useEffect(() => {

--- a/features/todo/templates/TodoWrapper.tsx
+++ b/features/todo/templates/TodoWrapper.tsx
@@ -133,15 +133,11 @@ const TodoContent = (): React.ReactElement => {
   // ユーザーIDが変わった時（ログアウト・ユーザー切り替え）にSWRキャッシュをクリア
   useEffect(() => {
     const currentUserId = sessionUser?.id;
-    if (
-      prevUserIdRef.current !== undefined &&
-      prevUserIdRef.current !== currentUserId
-    ) {
-      void globalMutate(todosApiUrl, undefined, { revalidate: false });
-      void globalMutate(listsApiUrl, undefined, { revalidate: false });
+    if (prevUserIdRef.current !== currentUserId) {
+      void globalMutate(() => true, undefined, { revalidate: false });
     }
     prevUserIdRef.current = currentUserId;
-  }, [sessionUser?.id, globalMutate, todosApiUrl, listsApiUrl]);
+  }, [sessionUser?.id, globalMutate]);
 
   // セッション待機の設定
   useEffect(() => {
@@ -159,7 +155,10 @@ const TodoContent = (): React.ReactElement => {
           }
         } catch (error) {
           // セッション更新失敗時はエラー表示へ
-          console.error('セッションの更新に失敗しました:', error);
+          console.error(
+            'セッションの更新に失敗しました:',
+            error instanceof Error ? error.message : String(error),
+          );
           setSessionGraceOver(true);
         }
       };
@@ -181,25 +180,28 @@ const TodoContent = (): React.ReactElement => {
   }, [shouldFetch, todosApiUrl, listsApiUrl]);
 
   // 共通のSWRオプション
-  const swrOptions = {
-    revalidateOnMount: true,
-    revalidateOnFocus: true, // タブ切り替え時に最新データ取得
-    revalidateOnReconnect: true, // オフライン復帰時に再取得
-    dedupingInterval: 2000, // 2秒以内の重複リクエストを防止
-    focusThrottleInterval: 5000, // フォーカス時の再検証を5秒に1回に制限
-    suspense: false,
-    shouldRetryOnError: (err: Error) => {
-      // FetchErrorの場合はステータスコードでチェック
-      if (isFetchError(err)) {
-        // 401 (Unauthorized) または 403 (Forbidden) の場合はリトライしない
-        return err.status !== 401 && err.status !== 403;
-      }
-      // その他のエラーはリトライしない（ネットワークエラー等）
-      return false;
-    },
-    errorRetryCount: 3,
-    errorRetryInterval: 1000,
-  };
+  const swrOptions = useMemo(
+    () => ({
+      revalidateOnMount: true,
+      revalidateOnFocus: true, // タブ切り替え時に最新データ取得
+      revalidateOnReconnect: true, // オフライン復帰時に再取得
+      dedupingInterval: 2000, // 2秒以内の重複リクエストを防止
+      focusThrottleInterval: 5000, // フォーカス時の再検証を5秒に1回に制限
+      suspense: false,
+      shouldRetryOnError: (err: Error) => {
+        // FetchErrorの場合はステータスコードでチェック
+        if (isFetchError(err)) {
+          // 401 (Unauthorized) または 403 (Forbidden) の場合はリトライしない
+          return err.status !== 401 && err.status !== 403;
+        }
+        // その他のエラーはリトライしない（ネットワークエラー等）
+        return false;
+      },
+      errorRetryCount: 3,
+      errorRetryInterval: 1000,
+    }),
+    [],
+  );
 
   const {
     data: todosData,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "firebase-admin": "^13.6.1",
         "gray-matter": "^4.0.3",
         "next": "16.1.6",
-        "next-auth": "^5.0.0-beta.30",
+        "next-auth": "5.0.0-beta.30",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-error-boundary": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "firebase-admin": "^13.6.1",
     "gray-matter": "^4.0.3",
     "next": "16.1.6",
-    "next-auth": "^5.0.0-beta.30",
+    "next-auth": "5.0.0-beta.30",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-error-boundary": "^5.0.0",

--- a/tests/features/todo/components/elements/Error/ErrorDisplay.test.tsx
+++ b/tests/features/todo/components/elements/Error/ErrorDisplay.test.tsx
@@ -32,7 +32,7 @@ describe('ErrorDisplay', () => {
     it('ErrorIconが表示される', () => {
       render(<ErrorDisplay {...defaultProps} />);
 
-      const errorIcon = screen.getByLabelText('errorIcon');
+      const errorIcon = screen.getByTestId('ErrorIcon');
       // ErrorIconのSVG要素を確認
       expect(errorIcon).toBeInTheDocument();
     });

--- a/tests/features/todo/templates/TodoWrapper.test.tsx
+++ b/tests/features/todo/templates/TodoWrapper.test.tsx
@@ -87,6 +87,7 @@ vi.mock('swr', () => ({
   },
   SWRConfig: ({ children }: { children: React.ReactNode }) => children,
   preload: vi.fn(),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
 }));
 
 describe('TodoWrapper', () => {


### PR DESCRIPTION
## 関連Issue

close #81

## 問題

ログアウト後に別ユーザーでログインすると、前ユーザーの todos・lists が表示される。再リロードすると正しいデータが表示される。

## 原因

サインアウト時に SWR キャッシュがクリアされず、前ユーザーのデータが残存していた。

## 修正内容

- ユーザーID変化を `useRef` で監視し、変化時に `globalMutate(() => true)` で全SWRキャッシュをクリア
- キャッシュクリア条件を修正し、`undefined` 遷移（ログアウト → 別ユーザーログイン）でも確実に発動するよう対応

## その他の改善（コードレビュー対応）

- `swrOptions` を `useMemo` でラップし、レンダリングごとの不要な参照生成を防止
- `console.error` でのエラーオブジェクト直接出力を `error.message` のみに変更（セッション情報の露出防止）
- ローディングスピナーに `role="status"` と `aria-label="読み込み中"` を追加（アクセシビリティ対応）
- `ErrorIcon` の `aria-label="errorIcon"` を `aria-hidden="true"` に変更（装飾アイコンの二重読み上げ防止）
- `next-auth` のバージョンを `^5.0.0-beta.30` → `5.0.0-beta.30` に固定（意図しない自動アップグレード防止）

## Test plan

- [ ] ログアウト後に別ユーザーでログインした際、前ユーザーのデータが表示されないこと
- [ ] リロードなしで正しいデータが表示されること
- [ ] サインイン・サインアウトフローが正常動作すること
- [ ] ローディング中にスクリーンリーダーで「読み込み中」が読み上げられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **改善**
  * ローディング スピナーのアクセシビリティを強化しました
  * エラーアイコンのアクセシビリティ属性を更新しました
  * ユーザー切り替え時およびログアウト時のセッション管理を改善し、キャッシュをクリアするようにしました

* **Chores**
  * 依存関係を最新版にアップデートしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->