### PR TITLE
fix: add id-token write permission for claude-code-action

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -1,0 +1,78 @@
+name: Auto PR Review Response (Claude)
+
+# CodeRabbit・Gemini Code Assistがレビューを投稿したタイミングで自動起動
+on:
+  pull_request_review:
+    types: [submitted]
+
+# 同一PRで複数のレビューが届いても1つずつ順番に処理する
+concurrency:
+  group: auto-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # ブランチへのcommit/push
+  pull-requests: write # コメント投稿・スレッド解決
+  id-token: write # claude-code-action@v1 のOIDC認証に必要
+
+jobs:
+  auto-response:
+    name: Claude Auto Review Response
+    runs-on: ubuntu-latest
+
+    # CodeRabbit・Gemini Code Assistのレビューのみに反応（他のレビュアーは手動対応）
+    if: |
+      github.event.review.user.login == 'coderabbitai[bot]' ||
+      github.event.review.user.login == 'gemini-code-assist[bot]'
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install gh-pr-review extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh extension install agynio/gh-pr-review
+
+      # CodeRabbit・Gemini Code Assistが全コメントを投稿し終えるのを待つ
+      - name: Wait for reviewer bot to finish posting all comments
+        run: sleep 60
+
+      - name: Run Claude PR Review Workflow
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "coderabbitai[bot],gemini-code-assist[bot]"
+          track_progress: true
+          claude_args: "--skip-permissions"
+          prompt: |
+            ## 実行環境
+            - GitHub Actions CI環境
+            - PR番号: #${{ github.event.pull_request.number }}
+            - リポジトリ: ${{ github.repository }}
+            - ブランチ: ${{ github.event.pull_request.head.ref }}
+
+            ## タスク
+            `.claude/skills/pr-review-todoapp/SKILL.md` を読み込み、定義された手順に従いPRレビュー対応を完全に実行してください。
+
+            ## 追加制約
+            - コミットメッセージには必ず '[skip ci]' を含めること（ワークフロー無限ループ防止）
+            - 形式例: 'fix: address PR review feedback [skip ci]'


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` が必要とする `id-token: write` 権限が不足していたため追加
- これによりOIDC認証エラーが解消される

## エラー内容
```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)