### PR TITLE
fix: add id-token write permission for claude-code-action

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -17,6 +17,7 @@ concurrency:
 permissions:
   contents: write # ブランチへのcommit/push
   pull-requests: write # コメント投稿・スレッド解決
+  id-token: write # claude-code-action@v1 のOIDC認証に必要
 
 jobs:
   auto-response:


### PR DESCRIPTION
## Summary
`id-token: write` 権限を追加（1行の変更のみ）

## エラー内容
```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)