### PR TITLE
fix: resolve issue_comment branch ref for claude-code-action

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -38,10 +38,27 @@ jobs:
       ))
 
     steps:
+      # issue_commentイベントではgithub.event.pull_requestが存在しないため
+      # PRのhead refをGitHub APIで動的に取得する
+      - name: Get PR info
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+            BRANCH=$(gh pr view ${PR_NUMBER} --repo ${{ github.repository }} --json headRefName -q .headRefName)
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          fi
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ steps.pr_info.outputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -72,15 +89,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: 'coderabbitai[bot],gemini-code-assist[bot]'
+          allowed_bots: "coderabbitai[bot],gemini-code-assist[bot]"
           track_progress: true
-          claude_args: '--skip-permissions'
+          claude_args: "--skip-permissions"
           prompt: |
             ## 実行環境
             - GitHub Actions CI環境
-            - PR番号: #${{ github.event.pull_request.number || github.event.issue.number }}
+            - PR番号: #${{ steps.pr_info.outputs.pr_number }}
             - リポジトリ: ${{ github.repository }}
-            - ブランチ: ${{ github.event.pull_request.head.ref }}
+            - ブランチ: ${{ steps.pr_info.outputs.branch }}
 
             ## タスク
             `.claude/skills/pr-review-todoapp/SKILL.md` を読み込み、定義された手順に従いPRレビュー対応を完全に実行してください。


### PR DESCRIPTION
## Summary
`issue_comment` イベントで `github.event.pull_request.head.ref` が空になる問題を修正。

## 変更内容
- PRブランチ名をGitHub APIで動的に取得するステップを追加
- `issue_comment` と `pull_request_review` の両イベントに対応
- `id-token: write` 権限を維持

## 修正したエラー
```
- ブランチ:   ← 空になっていた
Environment variable validation failed
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)