### PR TITLE
fix: ANTHROPIC_API_KEY env var for claude-code-action [skip ci]

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Run Claude PR Review Workflow
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "coderabbitai[bot],gemini-code-assist[bot]"


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` が `ANTHROPIC_API_KEY` を環境変数として要求するため、`env` セクションに明示的に追加
- `with.anthropic_api_key` パラメータだけでは不十分だったため、`env: ANTHROPIC_API_KEY:` も追加

## 変更内容
```yaml
- name: Run Claude PR Review Workflow
  uses: anthropics/claude-code-action@v1
  env:
    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # ← 追加
  with:
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
```

## エラー内容（修正前）
```
Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)