### PR TITLE
feat: add pr-review-todoapp SKILL.md and fix workflow prompt [skip ci]

### DIFF
--- a/.claude/skills/pr-review-todoapp/SKILL.md
+++ b/.claude/skills/pr-review-todoapp/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: pr-review-todoapp
+description: CodeRabbit・Gemini Code AssistのPRレビューコメントを解析し、指摘事項を自動修正してコミット・プッシュし、レビュースレッドに返信・解決するスキル。
+---
+
+# PR レビュー自動対応ワークフロー
+
+## 概要
+
+このスキルはGitHub ActionsのCI環境で実行される。
+CodeRabbit・Gemini Code Assistのレビューコメントを解析し、
+コードを修正してコミット・プッシュし、スレッドに返信する。
+
+## 前提条件
+
+- 環境変数 `GH_TOKEN`（または `GITHUB_TOKEN`）が設定済み
+- `gh` コマンドが利用可能
+- `gh-pr-review` extension がインストール済み
+
+## ワークフロー
+
+### Step 1: PR情報とレビューコメントの取得
+
+```bash
+# PR番号はワークフローのpromptから取得済み
+# PRのレビューコメント一覧を取得
+gh pr view ${PR_NUMBER} --repo ${REPO} --json reviews,comments,reviewRequests
+gh pr view ${PR_NUMBER} --repo ${REPO} --comments
+```
+
+具体的なコマンド例：
+```bash
+gh pr view 97 --repo sakatai11/todoApp-next --comments
+```
+
+### Step 2: レビューコメントの解析
+
+取得したコメントから以下を特定する：
+1. **未解決のスレッド**（resolved でないもの）
+2. **修正が必要な指摘**（LGTM・称賛・質問でないもの）
+3. **指摘されたファイルと行番号**
+
+### Step 3: コードの修正
+
+各指摘事項について：
+1. 対象ファイルを Read で読み込む
+2. 指摘内容を理解して修正案を作成
+3. Edit で修正を適用
+
+**修正の原則：**
+- セキュリティ指摘：最優先で対応
+- バグ・ロジックエラー：必ず対応
+- パフォーマンス改善：内容を確認して対応
+- コードスタイル：プロジェクトの規約に従って対応
+- 単なる提案・質問：コメントで返答のみ、コード修正は不要
+
+### Step 4: ビルド確認（オプション）
+
+修正後にビルドエラーがないか確認できる場合：
+```bash
+npm run build 2>&1 | tail -20
+```
+
+### Step 5: 変更のコミットとプッシュ
+
+```bash
+git add -A
+git commit -m "fix: address PR review feedback [skip ci]"
+```
+
+プッシュは `git push` コマンドを直接実行する。
+
+**重要**: コミットメッセージには必ず `[skip ci]` を含める（ワークフローの無限ループ防止）。
+
+### Step 6: PRコメントでの返信
+
+各指摘事項に対して、PRコメントで対応内容を報告する：
+
+```bash
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "## レビュー対応完了
+
+以下の指摘事項に対応しました：
+
+### 対応した修正
+- [ファイル名]: [修正内容の説明]
+
+### 対応しなかった指摘（理由付き）
+- [指摘内容]: [対応しなかった理由]
+
+修正内容をご確認ください。"
+```
+
+### Step 7: レビュースレッドの解決
+
+`gh-pr-review` extensionを使用してスレッドを解決する：
+
+```bash
+# 解決済みスレッドをマーク（gh-pr-review extensionが利用可能な場合）
+gh pr-review resolve --pr ${PR_NUMBER} --repo ${REPO}
+```
+
+extensionが動作しない場合は、コメントで「対応完了」を明示するだけで良い。
+
+## 注意事項
+
+- コミットメッセージには必ず `[skip ci]` を含めること
+- 修正できない指摘は、理由を明示してコメントで返答する
+- 破壊的変更（APIの変更、DBスキーマ変更など）は実施せず、コメントで確認を求める
+- テストファイルの修正も必要に応じて行う
+
+## エラーハンドリング
+
+**gh コマンドが失敗した場合**:
+- `GH_TOKEN` 環境変数を確認
+- `GITHUB_TOKEN` 環境変数にフォールバック
+
+**git push が失敗した場合**:
+- `git pull --rebase` してから再度プッシュ
+
+**修正方法が不明な指摘がある場合**:
+- コメントで「対応方法を確認中」と返答し、可能な限り修正を試みる

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -97,13 +97,17 @@ jobs:
           prompt: |
             ## 実行環境
             - GitHub Actions CI環境
-            - PR番号: #${{ steps.pr_info.outputs.pr_number }}
+            - PR番号: ${{ steps.pr_info.outputs.pr_number }}
             - リポジトリ: ${{ github.repository }}
             - ブランチ: ${{ steps.pr_info.outputs.branch }}
 
             ## タスク
-            `.claude/skills/pr-review-todoapp/SKILL.md` を読み込み、定義された手順に従いPRレビュー対応を完全に実行してください。
+            まず `.claude/skills/pr-review-todoapp/SKILL.md` を Read ツールで読み込んでください。
+            読み込んだ手順に従い、PR #${{ steps.pr_info.outputs.pr_number }} へのレビュー対応を実行してください。
 
-            ## 追加制約
+            SKILL.md内の `${PR_NUMBER}` は `${{ steps.pr_info.outputs.pr_number }}` に、
+            `${REPO}` は `${{ github.repository }}` に置き換えて使用してください。
+
+            ## 絶対制約
             - コミットメッセージには必ず '[skip ci]' を含めること（ワークフロー無限ループ防止）
             - 形式例: 'fix: address PR review feedback [skip ci]'


### PR DESCRIPTION
## 問題

`.claude/skills/pr-review-todoapp/SKILL.md` が存在しなかったため、Claude Code がファイル読み込みに失敗し、WebSearch でカバーしようとして（CIで禁止）クラッシュしていた。

## 変更内容

### 1. SKILL.md 新規作成
`.claude/skills/pr-review-todoapp/SKILL.md`
- CI環境に特化したPRレビュー対応ワークフロー（9ステップ）
- `gh pr view` でコメント取得 → 修正 → `git commit [skip ci]` → `gh pr comment` で返信

### 2. ワークフローprompt修正
`.github/workflows/auto-pr-review.yml`
- `Read ツールで読み込んでください` と明示的に指示
- `${PR_NUMBER}` / `${REPO}` の変数展開方法を明示

## テスト

マージ後、PR #97 に `@coderabbitai please review the changes again` とコメントして動作確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)