### PR TITLE
fix: set ANTHROPIC_API_KEY at job level [skip ci]

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -23,6 +23,8 @@ jobs:
   auto-response:
     name: Claude Auto Review Response
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
     # CodeRabbit・Gemini Code Assistのみに反応（他のレビュアーは手動対応）
     # issue_commentはPR上のコメントのみ対象（issue本体のコメントは除外）


### PR DESCRIPTION
## 問題

`claude-code-action@v1` のcomposite action内の `bun run` サブステップで
`ANTHROPIC_API_KEY:` が空になっていた（ログで確認済み）。

`with.anthropic_api_key` や step-level `env:` では composite action内部の
サブプロセスに値が伝播しない。

## 変更内容

`ANTHROPIC_API_KEY` をジョブレベルの `env:` に設定することで、
全サブステップ・サブプロセスに確実に継承させる。

```yaml
jobs:
  auto-response:
    env:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # ← 追加
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフローの内部設定を更新し、API キーの可用性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->