### PR TITLE
fix: remove --skip-permissions to prevent WebSearch bypass [skip ci]

### DIFF
--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -93,7 +93,6 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "coderabbitai[bot],gemini-code-assist[bot]"
           track_progress: true
-          claude_args: "--skip-permissions"
           prompt: |
             ## 実行環境
             - GitHub Actions CI環境


### PR DESCRIPTION
## 問題

`claude_args: "--skip-permissions"` が `DISALLOWED_TOOLS: WebSearch,WebFetch` の制限をバイパスし、Claude CodeがWebSearchを試みてクラッシュしていた。

ログで確認：
```
Web search failed: Server error: no LLM provider could handle the message
→ Claude Code process exited with code 1
```

## 変更内容

`claude_args: "--skip-permissions"` を削除。
`claude-code-action@v1` は内部で非インタラクティブモードを管理するため、このフラグは不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)