### PR TITLE
feat: develop-v2マージ時に仕様書を自動更新するgitフックを追加

### DIFF
--- a/.claude/hooks/post-merge.sh
+++ b/.claude/hooks/post-merge.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# .claude/hooks/post-merge.sh
+#
+# develop-v2 へのマージ時に仕様書（todoApp-submodule/docs/）を自動更新するフック。
+# setup-git-hooks.sh によって .git/hooks/post-merge にシンボリックリンクされます。
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# develop-v2 のマージ時のみ実行
+[ "$CURRENT_BRANCH" = "develop-v2" ] || exit 0
+
+# 仕様書更新対象ファイルが変更されているか確認
+# 対象: app/, features/, types/, constants/ 配下の .ts/.tsx
+# 対象: scripts/ 配下の .ts
+# 除外: tests/**、*.config.ts
+CHANGED_SOURCE=$(git diff --name-only ORIG_HEAD HEAD -- \
+  'app/' 'features/' 'types/' 'constants/' 2>/dev/null \
+  | grep -E '\.(ts|tsx)$' \
+  | grep -v '\.test\.' \
+  | grep -v '\.spec\.' \
+  | grep -v '\.config\.ts$' \
+  || true)
+
+CHANGED_SCRIPTS=$(git diff --name-only ORIG_HEAD HEAD -- 'scripts/' 2>/dev/null \
+  | grep '\.ts$' \
+  || true)
+
+if [ -z "$CHANGED_SOURCE" ] && [ -z "$CHANGED_SCRIPTS" ]; then
+  echo "📚 [update-specs] 仕様書更新対象の変更なし - スキップ"
+  exit 0
+fi
+
+# Claude Code CLI の存在確認
+if ! command -v claude &>/dev/null; then
+  echo ""
+  echo "⚠️  [update-specs] claude コマンドが見つかりません。"
+  echo "    Claude Code CLI をインストール後、手動で /update-specs を実行してください。"
+  exit 0
+fi
+
+# ファイル検出と同じ範囲（ORIG_HEAD..HEAD）をそのままClaudeに渡す
+ORIG_HEAD_SHA=$(cat "$(git rev-parse --git-dir)/ORIG_HEAD")
+COMMIT_RANGE="${ORIG_HEAD_SHA}..HEAD"
+
+echo ""
+echo "📚 ============================================"
+echo "📚 [update-specs] 仕様書の自動更新を開始します"
+echo "📚 ブランチ       : $CURRENT_BRANCH"
+echo "📚 コミット範囲   : $COMMIT_RANGE"
+echo "📚 ============================================"
+echo ""
+
+# プロジェクトルートで実行
+cd "$(git rev-parse --show-toplevel)"
+
+# スキルを実行（ファイル検出と同じ範囲を指定）
+# --dangerously-skip-permissions: バックグラウンド実行のため確認プロンプトをスキップ
+claude --dangerously-skip-permissions -p "/update-specs ${COMMIT_RANGE}"
+
+EXIT_CODE=$?
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "📚 [update-specs] 仕様書の更新が完了しました"
+else
+  echo "⚠️  [update-specs] 実行中にエラーが発生しました (exit: $EXIT_CODE)"
+  echo "    手動で /update-specs を実行して確認してください"
+fi
+
+# フックのエラーで git 操作自体を妨げない
+exit 0

--- a/.claude/hooks/post-merge.sh
+++ b/.claude/hooks/post-merge.sh
@@ -39,7 +39,7 @@ if ! command -v claude &>/dev/null; then
 fi
 
 # ファイル検出と同じ範囲（ORIG_HEAD..HEAD）をそのままClaudeに渡す
-ORIG_HEAD_SHA=$(cat "$(git rev-parse --git-dir)/ORIG_HEAD")
+ORIG_HEAD_SHA=$(git rev-parse ORIG_HEAD)
 COMMIT_RANGE="${ORIG_HEAD_SHA}..HEAD"
 
 echo ""

--- a/.claude/hooks/setup-git-hooks.sh
+++ b/.claude/hooks/setup-git-hooks.sh
@@ -31,8 +31,9 @@ install_hook() {
 
   # 既存フック（シンボリックリンク以外）はバックアップ
   if [ -f "$target_file" ] && [ ! -L "$target_file" ]; then
-    echo "  ⚠️  既存フックをバックアップ: ${target_file}.bak"
-    mv "$target_file" "${target_file}.bak"
+    local backup_file="${target_file}.bak.$(date +%Y%m%d%H%M%S)"
+    echo "  ⚠️  既存フックをバックアップ: ${backup_file}"
+    mv "$target_file" "$backup_file"
   fi
 
   ln -sf "$source_file" "$target_file"

--- a/.claude/hooks/setup-git-hooks.sh
+++ b/.claude/hooks/setup-git-hooks.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# .claude/hooks/setup-git-hooks.sh
+#
+# .claude/hooks/ のフックスクリプトを .git/hooks/ にシンボリックリンクします。
+# クローン後や新環境のセットアップ時に一度だけ実行してください。
+#
+# 使用方法:
+#   bash .claude/hooks/setup-git-hooks.sh
+
+set -e
+
+# スクリプト自身の場所からプロジェクトルートを確実に特定する
+# （git rev-parse はサブモジュール内で誤ったパスを返す場合があるため使用しない）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+CUSTOM_HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+
+echo "🔧 Git フックのセットアップを開始します..."
+echo ""
+
+install_hook() {
+  local hook_name="$1"
+  local source_file="$CUSTOM_HOOKS_DIR/${hook_name}.sh"
+  local target_file="$GIT_HOOKS_DIR/$hook_name"
+
+  if [ ! -f "$source_file" ]; then
+    echo "  ⚠️  スキップ: $source_file が存在しません"
+    return
+  fi
+
+  # 既存フック（シンボリックリンク以外）はバックアップ
+  if [ -f "$target_file" ] && [ ! -L "$target_file" ]; then
+    echo "  ⚠️  既存フックをバックアップ: ${target_file}.bak"
+    mv "$target_file" "${target_file}.bak"
+  fi
+
+  ln -sf "$source_file" "$target_file"
+  chmod +x "$source_file"
+  echo "  ✅ $hook_name → $source_file"
+}
+
+install_hook "post-merge"
+
+echo ""
+echo "✨ セットアップ完了"
+echo ""
+echo "─────────────────────────────────────────────"
+echo " 動作タイミング"
+echo "─────────────────────────────────────────────"
+echo "  git pull / git merge を develop-v2 上で実行したとき"
+echo "  app/, features/, types/, constants/, scripts/*.ts"
+echo "  のいずれかに変更があると /update-specs が自動起動します"
+echo ""
+echo " 前提条件"
+echo "─────────────────────────────────────────────"
+echo "  claude コマンドが利用可能であること"
+echo "  $ claude --version  で確認"
+echo ""
+echo " フックの無効化"
+echo "─────────────────────────────────────────────"
+echo "  $ rm .git/hooks/post-merge"
+echo "─────────────────────────────────────────────"


### PR DESCRIPTION
## 概要

develop-v2ブランチへのマージ後に `git pull` を実行すると、仕様書（`todoApp-submodule/docs/`）が自動更新される仕組みをgitフックで実装しました。

## 主な変更点

- **`.claude/hooks/post-merge.sh`**: gitフック本体
  - `develop-v2` ブランチでのみ発火
  - `app/`, `features/`, `types/`, `constants/`, `scripts/*.ts` の変更を検出
  - `ORIG_HEAD..HEAD` の範囲を Claude に渡し、ファイル検出とコミット範囲を統一
  - `claude` コマンド未インストール時は警告のみ表示し git 操作を妨げない
- **`.claude/hooks/setup-git-hooks.sh`**: セットアップスクリプト
  - `.git/hooks/post-merge` へのシンボリックリンクを作成
  - 新規クローン環境での初回セットアップ用（一度だけ実行）

## 関連 Issue

なし

## スクリーンショット（必要に応じて）

なし

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💄 UI/スタイル変更 (UI/Style changes)
- [ ] ⚡ パフォーマンス改善 (Performance improvement)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 📝 ドキュメント更新 (Documentation)
- [ ] 🧪 テスト追加・修正 (Tests)
- [x] 🔧 設定・ツール変更 (Configuration/Tools)
- [ ] 🚀 デプロイ・インフラ (Deploy/Infrastructure)

## テスト

- [ ] ユニットテスト実行済み (`npm run test`)
- [ ] 統合テスト実行済み (`npm run docker:test:run`)
- [ ] E2E テスト実行済み (`npm run docker:e2e:run`)
- [ ] Lint/Format 実行済み (`npm run format`)

フック動作の手動テスト実施済み:
- ORIG_HEAD を手動設定して `bash .claude/hooks/post-merge.sh` を直接実行
- ブランチ検出・ソースファイル変更検出・Claude 起動を確認

## チェックリスト

- [x] コードレビューの準備ができている
- [ ] 関連するドキュメントを更新した
- [ ] 破壊的変更がある場合、適切に文書化した
- [x] セキュリティ上の問題がないことを確認した
- [x] 機密情報や API キーが含まれていない

## 追加の注意事項

新しい開発環境にクローンした際は、以下のセットアップコマンドを一度実行する必要があります：

```bash
bash .claude/hooks/setup-git-hooks.sh
```

フックは `develop-v2` ブランチ上での `git pull` / `git merge` 時のみ発火します。`git pull --rebase` では発火しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Git フック自動セットアップスクリプトを追加しました。マージ後に仕様ファイルの自動更新処理が実行される環境が整備されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->