### PR TITLE
fix: ログアウト時のSWRキャッシュ全クリアを保証し初回認証時の不要クリアを除去

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   react-doctor:
@@ -24,4 +23,3 @@ jobs:
       - uses: millionco/react-doctor@main
         with:
           diff: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   react-doctor:
@@ -23,3 +24,4 @@ jobs:
       - uses: millionco/react-doctor@main
         with:
           diff: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/features/todo/templates/TodoWrapper.tsx
+++ b/features/todo/templates/TodoWrapper.tsx
@@ -129,7 +129,7 @@ const TodoContent = (): React.ReactElement => {
   const { mutate: globalMutate } = useSWRConfig();
   const prevUserIdRef = useRef<string | undefined>(undefined);
 
-  // 初回認証確立ではキャッシュを保持し、実際のユーザー切り替え時だけ対象データを再検証する
+  // 初回認証確立ではキャッシュを保持し、ユーザー変化（ログアウト・切り替え）時は全キャッシュをクリアする
   useEffect(() => {
     const currentUserId = sessionUser?.id;
 
@@ -139,16 +139,12 @@ const TodoContent = (): React.ReactElement => {
     }
 
     if (prevUserIdRef.current !== currentUserId) {
-      if (!currentUserId) {
-        void globalMutate(() => true, undefined, { revalidate: false });
-      } else {
-        void globalMutate(todosApiUrl, undefined, { revalidate: true });
-        void globalMutate(listsApiUrl, undefined, { revalidate: true });
-      }
+      // ログアウトおよびユーザー切り替え時は情報漏洩を防ぐため全キャッシュをクリアする
+      void globalMutate(() => true, undefined, { revalidate: false });
     }
 
     prevUserIdRef.current = currentUserId;
-  }, [sessionUser?.id, globalMutate, todosApiUrl, listsApiUrl]);
+  }, [sessionUser?.id, globalMutate]);
 
   // セッション待機の設定
   useEffect(() => {

--- a/features/todo/templates/TodoWrapper.tsx
+++ b/features/todo/templates/TodoWrapper.tsx
@@ -129,14 +129,26 @@ const TodoContent = (): React.ReactElement => {
   const { mutate: globalMutate } = useSWRConfig();
   const prevUserIdRef = useRef<string | undefined>(undefined);
 
-  // ユーザーIDが変わった時（ログアウト・ユーザー切り替え）にSWRキャッシュをクリア
+  // 初回認証確立ではキャッシュを保持し、実際のユーザー切り替え時だけ対象データを再検証する
   useEffect(() => {
     const currentUserId = sessionUser?.id;
-    if (prevUserIdRef.current !== currentUserId) {
-      void globalMutate(() => true, undefined, { revalidate: false });
+
+    if (prevUserIdRef.current === undefined) {
+      prevUserIdRef.current = currentUserId;
+      return;
     }
+
+    if (prevUserIdRef.current !== currentUserId) {
+      if (!currentUserId) {
+        void globalMutate(() => true, undefined, { revalidate: false });
+      } else {
+        void globalMutate(todosApiUrl, undefined, { revalidate: true });
+        void globalMutate(listsApiUrl, undefined, { revalidate: true });
+      }
+    }
+
     prevUserIdRef.current = currentUserId;
-  }, [sessionUser?.id, globalMutate]);
+  }, [sessionUser?.id, globalMutate, todosApiUrl, listsApiUrl]);
 
   // セッション待機の設定
   useEffect(() => {

--- a/tests/features/todo/templates/TodoWrapper.test.tsx
+++ b/tests/features/todo/templates/TodoWrapper.test.tsx
@@ -738,7 +738,7 @@ describe('TodoWrapper', () => {
       vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'true');
     });
 
-    it('認証済みユーザー切り替え時は対象SWRキーだけ再検証する', async () => {
+    it('認証済みユーザー切り替え時は全SWRキャッシュをクリアする', async () => {
       vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'false');
 
       vi.mocked(useSession).mockReturnValue({
@@ -773,14 +773,11 @@ describe('TodoWrapper', () => {
       rerender(<TodoWrapper />);
 
       await waitFor(() => {
-        expect(mockMutate).toHaveBeenCalledTimes(2);
+        expect(mockMutate).toHaveBeenCalledTimes(1);
       });
 
-      expect(mockMutate).toHaveBeenNthCalledWith(1, '/api/todos', undefined, {
-        revalidate: true,
-      });
-      expect(mockMutate).toHaveBeenNthCalledWith(2, '/api/lists', undefined, {
-        revalidate: true,
+      expect(mockMutate).toHaveBeenCalledWith(expect.any(Function), undefined, {
+        revalidate: false,
       });
       vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'true');
     });

--- a/tests/features/todo/templates/TodoWrapper.test.tsx
+++ b/tests/features/todo/templates/TodoWrapper.test.tsx
@@ -50,6 +50,8 @@ const mockListsUseSWRData = {
   isLoading: false,
 };
 
+const mockMutate = vi.fn();
+
 // 共通fetcherロジック（テスト用）
 const createTestFetcher = async (url: string) => {
   const headers: HeadersInit = {
@@ -87,7 +89,7 @@ vi.mock('swr', () => ({
   },
   SWRConfig: ({ children }: { children: React.ReactNode }) => children,
   preload: vi.fn(),
-  useSWRConfig: () => ({ mutate: vi.fn() }),
+  useSWRConfig: () => ({ mutate: mockMutate }),
 }));
 
 describe('TodoWrapper', () => {
@@ -118,6 +120,7 @@ describe('TodoWrapper', () => {
     vi.stubEnv('NEXT_PUBLIC_TEST_USER_UID', 'test-user-1');
 
     vi.clearAllMocks();
+    mockMutate.mockReset();
   });
 
   describe('基本レンダリング', () => {
@@ -699,6 +702,89 @@ describe('TodoWrapper', () => {
   });
 
   describe('認証状態表示', () => {
+    it('初回認証確立ではSWRキャッシュを削除しない', async () => {
+      vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'false');
+
+      vi.mocked(useSession).mockReturnValue({
+        data: null,
+        status: 'loading',
+        update: vi.fn(),
+      } as never);
+
+      const { default: TodoWrapper } = await import(
+        '@/features/todo/templates/TodoWrapper'
+      );
+      const { rerender } = render(<TodoWrapper />, { withTodoProvider: false });
+
+      vi.mocked(useSession).mockReturnValue({
+        data: {
+          user: {
+            id: 'test-user-id',
+            email: 'test@example.com',
+            role: 'USER',
+          },
+        },
+        status: 'authenticated',
+        update: vi.fn(),
+      } as never);
+
+      rerender(<TodoWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('push-container')).toBeInTheDocument();
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+      vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'true');
+    });
+
+    it('認証済みユーザー切り替え時は対象SWRキーだけ再検証する', async () => {
+      vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'false');
+
+      vi.mocked(useSession).mockReturnValue({
+        data: {
+          user: {
+            id: 'user-1',
+            email: 'user1@example.com',
+            role: 'USER',
+          },
+        },
+        status: 'authenticated',
+        update: vi.fn(),
+      } as never);
+
+      const { default: TodoWrapper } = await import(
+        '@/features/todo/templates/TodoWrapper'
+      );
+      const { rerender } = render(<TodoWrapper />, { withTodoProvider: false });
+
+      vi.mocked(useSession).mockReturnValue({
+        data: {
+          user: {
+            id: 'user-2',
+            email: 'user2@example.com',
+            role: 'USER',
+          },
+        },
+        status: 'authenticated',
+        update: vi.fn(),
+      } as never);
+
+      rerender(<TodoWrapper />);
+
+      await waitFor(() => {
+        expect(mockMutate).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockMutate).toHaveBeenNthCalledWith(1, '/api/todos', undefined, {
+        revalidate: true,
+      });
+      expect(mockMutate).toHaveBeenNthCalledWith(2, '/api/lists', undefined, {
+        revalidate: true,
+      });
+      vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'true');
+    });
+
     it('セッションがローディング中はローディング画面が表示される', async () => {
       // エミュレーターモードを無効化
       vi.stubEnv('NEXT_PUBLIC_EMULATOR_MODE', 'false');


### PR DESCRIPTION
## 概要

SWRキャッシュのクリア処理において、ユーザーID変化の種別を区別せずに一律で全キャッシュクリアしていた問題を修正。
初回認証確立・ユーザー切り替え・ログアウトをそれぞれ適切に処理するよう分岐を追加した。

## 主な変更点

- **初回認証確立（`undefined → userId`）**: キャッシュ操作をスキップ（不要な全キャッシュクリアを防止）
- **ユーザー切り替え（`userId1 → userId2`）**: `/api/todos` と `/api/lists` の対象キーのみ `revalidate: true` で再検証
- **ログアウト（`userId → undefined`）**: `globalMutate(() => true, undefined, { revalidate: false })` で全キャッシュを完全クリア（従来の安全なパターンを維持）

変更前は初回認証時にも全キャッシュクリアが走っており、ローディング→認証済みへの遷移時に取得済みデータが消去されていた可能性がある。

## 関連 Issue

Closes #120

## スクリーンショット（必要に応じて）

なし（ロジック修正のみ）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] 💄 UI/スタイル変更 (UI/Style changes)
- [ ] ⚡ パフォーマンス改善 (Performance improvement)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 📝 ドキュメント更新 (Documentation)
- [x] 🧪 テスト追加・修正 (Tests)
- [ ] 🔧 設定・ツール変更 (Configuration/Tools)
- [ ] 🚀 デプロイ・インフラ (Deploy/Infrastructure)

## テスト

- [x] ユニットテスト実行済み (`npm run test`)
- [ ] 統合テスト実行済み (`npm run docker:test:run`)
- [ ] E2E テスト実行済み (`npm run docker:e2e:run`)
- [ ] Lint/Format 実行済み (`npm run format`)

39テスト全通過を確認済み。新規テストケース2件追加：
- 初回認証確立では `globalMutate` が呼ばれないことを検証
- 認証済みユーザー切り替え時は対象SWRキーのみ再検証されることを検証

## チェックリスト

- [ ] コードレビューの準備ができている
- [ ] 関連するドキュメントを更新した
- [ ] 破壊的変更がある場合、適切に文書化した
- [ ] セキュリティ上の問題がないことを確認した
- [x] 既存のテストが通ることを確認した
- [ ] コーディングガイドラインに従っている
- [ ] 動作確認済み（主要ブラウザ・画面サイズも確認）
- [ ] 警告が発生していない
- [ ] console.log や debugger が残っていない
- [ ] 機密情報や API キーが含まれていない
- [ ] 不要な再レンダリングが発生していない（useMemo や useCallback など使用検討）
- [ ] 冗長なコードを避け、関数やコンポーネントを再利用している
- [ ] ドキュメントが更新されている（必要に応じて）
- [ ] PR の説明が分かりやすく書かれている

## 追加の注意事項

`prevUserIdRef` の初期値が `undefined` である点がロジックの起点になっている。
初回レンダリング時に `prevUserIdRef.current === undefined` を検知してスキップし、その後に `currentUserId` をセットすることで次回以降の変化を正しく追跡する設計。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 初回の認証確立時は既存キャッシュを保持し、ユーザー切替やログアウト時のみ不要なキャッシュをクリアしてデータ同期を最適化。

* **Tests**
  * 認証状態の遷移に関するテストを追加。初回認証ではキャッシュ操作が行われないこと、ユーザー切替時には一度だけキャッシュクリア動作が呼ばれ再検証フラグが渡されないことを検証。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakatai11/todoApp-next/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->