### PR TITLE
feat: API ルートのリクエストボディに Zod バリデーションを導入

### DIFF
--- a/app/api/(admin)/users/[userId]/lists/route.ts
+++ b/app/api/(admin)/users/[userId]/lists/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@/auth';
 import { adminDB } from '@/app/libs/firebaseAdmin';
 import { NextResponse } from 'next/server';
 import { StatusListProps } from '@/types/lists';
+import { StatusListFirestoreDocSchema } from '@/data/validatedData';
 
 export async function GET(
   _request: Request,
@@ -21,14 +22,16 @@ export async function GET(
       .collection(`users/${userId}/lists`)
       .orderBy('number', 'asc')
       .get();
-    const lists: StatusListProps[] = listsSnap.docs.map((doc) => {
-      const d = doc.data();
-      return {
-        id: doc.id,
-        category: d['category'] as string,
-        number: d['number'] as number,
-      };
-    });
+    const lists: StatusListProps[] = listsSnap.docs
+      .map((doc): StatusListProps | null => {
+        const result = StatusListFirestoreDocSchema.safeParse(doc.data());
+        if (!result.success) {
+          console.warn('Skipping invalid list document:', doc.id);
+          return null;
+        }
+        return { id: doc.id, ...result.data };
+      })
+      .filter((list): list is StatusListProps => list !== null);
     return NextResponse.json({ lists }, { status: 200 });
   } catch (error) {
     console.error('Error in GET /api/users/[userId]/lists:', error);

--- a/app/api/(admin)/users/[userId]/route.ts
+++ b/app/api/(admin)/users/[userId]/route.ts
@@ -40,8 +40,8 @@ export async function GET(
       email,
       role,
       createdAt: createdAt.toMillis(),
-      name,
-      image,
+      name: name ?? undefined,
+      image: image ?? undefined,
       updatedAt: updatedAt?.toMillis(),
     };
 

--- a/app/api/(admin)/users/[userId]/route.ts
+++ b/app/api/(admin)/users/[userId]/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@/auth';
 import { adminDB } from '@/app/libs/firebaseAdmin';
 import { NextResponse } from 'next/server';
 import { AdminUser } from '@/types/auth/authData';
+import { AdminUserFirestoreDocSchema } from '@/data/validatedData';
 
 export async function GET(
   _request: Request,
@@ -26,20 +27,22 @@ export async function GET(
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
     const data = userDoc.data();
+    const parseResult = AdminUserFirestoreDocSchema.safeParse(data);
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: 'Invalid user data format' },
+        { status: 500 },
+      );
+    }
+    const { email, role, createdAt, name, image, updatedAt } = parseResult.data;
     const user: AdminUser = {
       id: userDoc.id,
-      email: data?.['email'] as string,
-      role: data?.['role'] as 'ADMIN' | 'USER',
-      createdAt:
-        (
-          data?.['createdAt'] as { toMillis: () => number } | undefined
-        )?.toMillis() ?? 0,
-      name: (data?.['name'] as string | undefined) ?? undefined,
-      image: (data?.['image'] as string | undefined) ?? undefined,
-      updatedAt:
-        (
-          data?.['updatedAt'] as { toMillis: () => number } | undefined
-        )?.toMillis() ?? undefined,
+      email,
+      role,
+      createdAt: createdAt.toMillis(),
+      name,
+      image,
+      updatedAt: updatedAt?.toMillis(),
     };
 
     return NextResponse.json({ user }, { status: 200 });

--- a/app/api/(admin)/users/[userId]/todos/route.ts
+++ b/app/api/(admin)/users/[userId]/todos/route.ts
@@ -2,7 +2,7 @@ import { auth } from '@/auth';
 import { adminDB } from '@/app/libs/firebaseAdmin';
 import { NextResponse } from 'next/server';
 import { TodoListProps } from '@/types/todos';
-import { Timestamp } from 'firebase-admin/firestore';
+import { TodoFirestoreDocSchema } from '@/data/validatedData';
 
 export async function GET(
   _request: Request,
@@ -22,17 +22,16 @@ export async function GET(
       .collection(`users/${userId}/todos`)
       .orderBy('updateTime', 'desc')
       .get();
-    const todos: TodoListProps[] = todosSnap.docs.map((doc) => {
-      const d = doc.data();
-      return {
-        id: doc.id,
-        updateTime: d['updateTime'] as Timestamp,
-        createdTime: d['createdTime'] as Timestamp,
-        text: d['text'] as string,
-        status: d['status'] as string,
-        bool: d['bool'] as boolean,
-      };
-    });
+    const todos: TodoListProps[] = todosSnap.docs
+      .map((doc): TodoListProps | null => {
+        const result = TodoFirestoreDocSchema.safeParse(doc.data());
+        if (!result.success) {
+          console.warn('Skipping invalid todo document:', doc.id);
+          return null;
+        }
+        return { id: doc.id, ...result.data };
+      })
+      .filter((todo): todo is TodoListProps => todo !== null);
     return NextResponse.json({ todos }, { status: 200 });
   } catch (error) {
     console.error('Error in GET /api/users/[userId]/todos:', error);

--- a/app/api/(admin)/users/route.ts
+++ b/app/api/(admin)/users/route.ts
@@ -31,8 +31,8 @@ export async function GET() {
           email,
           role,
           createdAt: createdAt.toMillis(),
-          name,
-          image,
+          name: name ?? undefined,
+          image: image ?? undefined,
         };
       })
       .filter((user): user is AdminUser => user !== null);

--- a/app/api/(admin)/users/route.ts
+++ b/app/api/(admin)/users/route.ts
@@ -2,6 +2,7 @@ import { auth } from '@/auth';
 import { adminDB } from '@/app/libs/firebaseAdmin';
 import { NextResponse } from 'next/server';
 import { AdminUser } from '@/types/auth/authData';
+import { AdminUserFirestoreDocSchema } from '@/data/validatedData';
 
 export async function GET() {
   try {
@@ -17,20 +18,24 @@ export async function GET() {
       .collection('users')
       .orderBy('createdAt', 'desc')
       .get();
-    const users: AdminUser[] = usersSnapshot.docs.map((doc) => {
-      const data = doc.data();
-      return {
-        id: doc.id,
-        email: data['email'] as string,
-        role: data['role'] as 'ADMIN' | 'USER',
-        createdAt:
-          (
-            data['createdAt'] as { toMillis: () => number } | undefined
-          )?.toMillis() ?? 0,
-        name: (data['name'] as string | undefined) ?? undefined,
-        image: (data['image'] as string | undefined) ?? undefined,
-      };
-    });
+    const users: AdminUser[] = usersSnapshot.docs
+      .map((doc): AdminUser | null => {
+        const result = AdminUserFirestoreDocSchema.safeParse(doc.data());
+        if (!result.success) {
+          console.warn('Skipping invalid user document:', doc.id);
+          return null;
+        }
+        const { email, role, createdAt, name, image } = result.data;
+        return {
+          id: doc.id,
+          email,
+          role,
+          createdAt: createdAt.toMillis(),
+          name,
+          image,
+        };
+      })
+      .filter((user): user is AdminUser => user !== null);
     return NextResponse.json({ users }, { status: 200 });
   } catch (error) {
     console.error('Error in GET /api/users:', error);

--- a/app/api/(general)/lists/route.ts
+++ b/app/api/(general)/lists/route.ts
@@ -121,12 +121,6 @@ export async function PUT(req: Request) {
 
         if (validatedPayload.type === 'update') {
           const { id } = validatedPayload;
-          if (!id || !validatedPayload.data?.category?.trim()) {
-            return NextResponse.json(
-              { error: 'ID and category are required' },
-              { status: 400 },
-            );
-          }
 
           await listsCollection.doc(id).update({
             category: validatedPayload.data.category,

--- a/app/api/(general)/lists/route.ts
+++ b/app/api/(general)/lists/route.ts
@@ -3,6 +3,12 @@ import { ListPayload, ListResponse, StatusListProps } from '@/types/lists';
 import { NextResponse } from 'next/server';
 import { withAuthenticatedUser } from '@/app/libs/withAuth';
 import { trimAllSpaces } from '@/app/utils/validationUtils';
+import {
+  StatusListFirestoreDocSchema,
+  ListPostBodySchema,
+  ListPutBodySchema,
+  ListDeleteBodySchema,
+} from '@/data/validatedData';
 
 /**
  * 認証されたユーザーのリストを取得します。
@@ -22,13 +28,16 @@ export async function GET(req: Request) {
         .orderBy('number', 'asc')
         .get();
 
-      const lists: StatusListProps[] = listsSnapshot.docs.map(
-        (doc) =>
-          ({
-            id: doc.id,
-            ...doc.data(),
-          }) as StatusListProps,
-      );
+      const lists: StatusListProps[] = listsSnapshot.docs
+        .map((doc) => {
+          const result = StatusListFirestoreDocSchema.safeParse(doc.data());
+          if (!result.success) {
+            console.warn('Skipping invalid list document:', doc.id);
+            return null;
+          }
+          return { id: doc.id, ...result.data };
+        })
+        .filter((list): list is StatusListProps => list !== null);
 
       return NextResponse.json({ lists }, { status: 200 });
     } catch (error) {
@@ -45,14 +54,15 @@ export async function POST(req: Request) {
   return withAuthenticatedUser<ListPayload<'POST'>, ListResponse<'POST'>>(
     req,
     async (uid, body) => {
-      if (!body) {
+      const parseResult = ListPostBodySchema.safeParse(body);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'Request body is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
 
-      const { category, number } = body;
+      const { category, number } = parseResult.data;
 
       const trimmedCategory = trimAllSpaces(category);
 
@@ -93,12 +103,15 @@ export async function PUT(req: Request) {
   return withAuthenticatedUser<ListPayload<'PUT'>, ListResponse<'PUT'>>(
     req,
     async (uid, payload) => {
-      if (!payload) {
+      const parseResult = ListPutBodySchema.safeParse(payload);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'payload is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
+
+      const validatedPayload = parseResult.data;
 
       try {
         const listsCollection = adminDB
@@ -106,10 +119,9 @@ export async function PUT(req: Request) {
           .doc(uid)
           .collection('lists');
 
-        // editList
-        if (payload.type === 'update') {
-          const { id } = payload;
-          if (!id || !payload.data?.category?.trim()) {
+        if (validatedPayload.type === 'update') {
+          const { id } = validatedPayload;
+          if (!id || !validatedPayload.data?.category?.trim()) {
             return NextResponse.json(
               { error: 'ID and category are required' },
               { status: 400 },
@@ -117,7 +129,7 @@ export async function PUT(req: Request) {
           }
 
           await listsCollection.doc(id).update({
-            category: payload.data.category,
+            category: validatedPayload.data.category,
           });
 
           return NextResponse.json(
@@ -126,10 +138,8 @@ export async function PUT(req: Request) {
           );
         }
 
-        // handleButtonMov
-        // handleDragEnd
-        if (payload.type === 'reorder') {
-          if (!Array.isArray(payload.data) || payload.data.length === 0) {
+        if (validatedPayload.type === 'reorder') {
+          if (validatedPayload.data.length === 0) {
             return NextResponse.json(
               { error: 'Valid order array is required' },
               { status: 400 },
@@ -137,15 +147,13 @@ export async function PUT(req: Request) {
           }
 
           await adminDB.runTransaction(async (transaction) => {
-            // 現在の全リストを取得
             const snapshot = await listsCollection.get();
             const currentLists = snapshot.docs.map((doc) => ({
               id: doc.id,
               ...doc.data(),
             }));
 
-            // バリデーション
-            const isValidOrder = payload.data.every((id) =>
+            const isValidOrder = validatedPayload.data.every((id) =>
               currentLists.some((list) => list.id === id),
             );
 
@@ -153,8 +161,7 @@ export async function PUT(req: Request) {
               throw new Error('Invalid list IDs in newOrder');
             }
 
-            // 新しい順序で番号更新
-            payload.data.forEach((listId, index) => {
+            validatedPayload.data.forEach((listId, index) => {
               const docRef = listsCollection.doc(listId);
               transaction.update(docRef, { number: index + 1 });
             });
@@ -187,14 +194,15 @@ export async function DELETE(req: Request) {
   return withAuthenticatedUser<ListPayload<'DELETE'>, ListResponse<'DELETE'>>(
     req,
     async (uid, body) => {
-      const id = body?.id;
-
-      if (!id) {
+      const parseResult = ListDeleteBodySchema.safeParse(body);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'ListDelete is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
+
+      const { id } = parseResult.data;
 
       try {
         const listsCollection = adminDB

--- a/app/api/(general)/todos/route.ts
+++ b/app/api/(general)/todos/route.ts
@@ -192,7 +192,10 @@ export async function PUT(req: Request) {
           return NextResponse.json(responseData, { status: 200 });
         }
 
-        if (validatedPayload.type === 'restatus') {
+        if (
+          'type' in validatedPayload &&
+          validatedPayload.type === 'restatus'
+        ) {
           const { oldStatus, status } = validatedPayload.data;
           const snapshot = await todosCollection.get();
           const batch = adminDB.batch();

--- a/app/api/(general)/todos/route.ts
+++ b/app/api/(general)/todos/route.ts
@@ -5,6 +5,12 @@ import { withAuthenticatedUser } from '@/app/libs/withAuth';
 import { TodoResponse } from '@/types/todos';
 import { Timestamp } from 'firebase-admin/firestore';
 import { trimAllSpaces } from '@/app/utils/validationUtils';
+import {
+  TodoFirestoreDocSchema,
+  TodoPostBodySchema,
+  TodoPutBodySchema,
+  TodoDeleteBodySchema,
+} from '@/data/validatedData';
 
 /**
  * 認証されたユーザーのtodoリストを取得します。
@@ -23,13 +29,16 @@ export async function GET(req: Request) {
         .collection('todos')
         .get();
 
-      const todos: TodoListProps[] = todosSnapshot.docs.map(
-        (doc) =>
-          ({
-            id: doc.id,
-            ...doc.data(),
-          }) as TodoListProps,
-      );
+      const todos: TodoListProps[] = todosSnapshot.docs
+        .map((doc) => {
+          const result = TodoFirestoreDocSchema.safeParse(doc.data());
+          if (!result.success) {
+            console.warn('Skipping invalid todo document:', doc.id);
+            return null;
+          }
+          return { id: doc.id, ...result.data };
+        })
+        .filter((todo): todo is TodoListProps => todo !== null);
 
       return NextResponse.json({ todos }, { status: 200 });
     } catch (error) {
@@ -51,14 +60,15 @@ export async function POST(req: Request) {
   return withAuthenticatedUser<TodoPayload<'POST'>, TodoResponse<'POST'>>(
     req,
     async (uid, body) => {
-      if (!body) {
+      const parseResult = TodoPostBodySchema.safeParse(body);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'Request body is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
 
-      const { text, status } = body;
+      const { text, status } = parseResult.data;
 
       const trimmedText = trimAllSpaces(text);
       const trimmedStatus = trimAllSpaces(status);
@@ -110,12 +120,15 @@ export async function PUT(req: Request) {
   return withAuthenticatedUser<TodoPayload<'PUT'>, TodoResponse<'PUT'>>(
     req,
     async (uid, payload) => {
-      if (!payload) {
+      const parseResult = TodoPutBodySchema.safeParse(payload);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'Request payload is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
+
+      const validatedPayload = parseResult.data;
 
       const todosCollection = adminDB
         .collection('users')
@@ -123,16 +136,22 @@ export async function PUT(req: Request) {
         .collection('todos');
 
       try {
-        if ('id' in payload && 'bool' in payload) {
-          await todosCollection.doc(payload.id).update({ bool: payload.bool });
+        if ('id' in validatedPayload && 'bool' in validatedPayload) {
+          await todosCollection
+            .doc(validatedPayload.id)
+            .update({ bool: validatedPayload.bool });
           return NextResponse.json(
             { message: 'Todo updated toggle' },
             { status: 200 },
           );
         }
 
-        if ('id' in payload && 'text' in payload && 'status' in payload) {
-          const { id, text, status } = payload;
+        if (
+          'id' in validatedPayload &&
+          'text' in validatedPayload &&
+          'status' in validatedPayload
+        ) {
+          const { id, text, status } = validatedPayload;
 
           const trimmedText = trimAllSpaces(text);
           const trimmedStatus = trimAllSpaces(status);
@@ -158,7 +177,6 @@ export async function PUT(req: Request) {
 
           await todosCollection.doc(id).update(updateData);
 
-          // 更新されたドキュメントを取得してレスポンスを返す
           const updatedDoc = await todosCollection.doc(id).get();
           const updatedTodo = updatedDoc.data();
 
@@ -174,8 +192,8 @@ export async function PUT(req: Request) {
           return NextResponse.json(responseData, { status: 200 });
         }
 
-        if (payload.type === 'restatus') {
-          const { oldStatus, status } = payload.data;
+        if (validatedPayload.type === 'restatus') {
+          const { oldStatus, status } = validatedPayload.data;
           const snapshot = await todosCollection.get();
           const batch = adminDB.batch();
 
@@ -216,13 +234,15 @@ export async function DELETE(req: Request) {
   return withAuthenticatedUser<TodoPayload<'DELETE'>, TodoResponse<'DELETE'>>(
     req,
     async (uid, body) => {
-      const id = body?.id;
-      if (!id) {
+      const parseResult = TodoDeleteBodySchema.safeParse(body);
+      if (!parseResult.success) {
         return NextResponse.json(
-          { error: 'TodoDelete is required' },
+          { error: 'Invalid request body' },
           { status: 400 },
         );
       }
+
+      const { id } = parseResult.data;
 
       try {
         await adminDB

--- a/app/api/(general)/user/route.ts
+++ b/app/api/(general)/user/route.ts
@@ -32,7 +32,14 @@ export async function GET() {
       }
       const { email, role, createdAt, name, image } = parseResult.data;
       userData = [
-        { id: uid, email, role, createdAt: createdAt.toMillis(), name, image },
+        {
+          id: uid,
+          email,
+          role,
+          createdAt: createdAt.toMillis(),
+          name: name ?? undefined,
+          image: image ?? undefined,
+        },
       ];
     }
 

--- a/app/api/(general)/user/route.ts
+++ b/app/api/(general)/user/route.ts
@@ -2,6 +2,7 @@ import { adminDB } from '@/app/libs/firebaseAdmin';
 import { auth } from '@/auth';
 import { NextResponse } from 'next/server';
 import { AdminUser } from '@/types/auth/authData';
+import { AdminUserFirestoreDocSchema } from '@/data/validatedData';
 
 // ユーザー情報を取得する関数
 export async function GET() {
@@ -19,20 +20,21 @@ export async function GET() {
     // Firestoreのusersコレクションからuidが一致するドキュメントを取得
     const doc = await adminDB.collection('users').doc(uid).get();
     const data = doc.data();
-    // 各データマッピング
-    const userData: AdminUser[] = data
-      ? [
-          {
-            id: uid,
-            email: data['email'] as string,
-            role: data['role'] as 'ADMIN' | 'USER',
-            createdAt:
-              (
-                data['createdAt'] as { toMillis: () => number } | undefined
-              )?.toMillis() ?? 0,
-          },
-        ]
-      : [];
+
+    let userData: AdminUser[] = [];
+    if (data) {
+      const parseResult = AdminUserFirestoreDocSchema.safeParse(data);
+      if (!parseResult.success) {
+        return NextResponse.json(
+          { error: 'Invalid user data format' },
+          { status: 500 },
+        );
+      }
+      const { email, role, createdAt, name, image } = parseResult.data;
+      userData = [
+        { id: uid, email, role, createdAt: createdAt.toMillis(), name, image },
+      ];
+    }
 
     // JSONレスポンスを返す
     return NextResponse.json({ user: userData }, { status: 200 });

--- a/data/validatedData.ts
+++ b/data/validatedData.ts
@@ -51,7 +51,7 @@ export const ListPutBodySchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('update'),
     id: z.string(),
-    data: z.object({ category: z.string().optional() }),
+    data: z.object({ category: z.string().trim().min(1) }),
   }),
 ]);
 
@@ -75,7 +75,7 @@ export const AdminUserFirestoreDocSchema = z.object({
   email: z.string(),
   role: z.enum(['ADMIN', 'USER']),
   createdAt: z.instanceof(Timestamp),
-  name: z.string().optional(),
-  image: z.string().optional(),
-  updatedAt: z.instanceof(Timestamp).optional(),
+  name: z.string().nullish(),
+  image: z.string().nullish(),
+  updatedAt: z.instanceof(Timestamp).nullish(),
 });

--- a/data/validatedData.ts
+++ b/data/validatedData.ts
@@ -27,8 +27,8 @@ export const TodoPostBodySchema = z.object({
 });
 
 export const TodoPutBodySchema = z.union([
-  z.object({ id: z.string(), bool: z.boolean() }),
-  z.object({ id: z.string(), text: z.string(), status: z.string() }),
+  z.object({ id: z.string().min(1), bool: z.boolean() }),
+  z.object({ id: z.string().min(1), text: z.string(), status: z.string() }),
   z.object({
     type: z.literal('restatus'),
     data: z.object({ oldStatus: z.string(), status: z.string() }),
@@ -50,7 +50,7 @@ export const ListPutBodySchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('update'),
-    id: z.string(),
+    id: z.string().min(1),
     data: z.object({ category: z.string().trim().min(1) }),
   }),
 ]);

--- a/data/validatedData.ts
+++ b/data/validatedData.ts
@@ -1,5 +1,6 @@
 // バリデーション付きの安全な実装例
 import { z } from 'zod';
+import { Timestamp } from 'firebase-admin/firestore';
 
 export const AuthDecodedTokenSchema = z.object({
   uid: z.string(),
@@ -16,4 +17,65 @@ export const AuthResponseSchema = z.object({
 export const CredentialsSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6),
+});
+
+// === タスクリクエストボディスキーマ ===
+export const TodoPostBodySchema = z.object({
+  text: z.string(),
+  status: z.string(),
+  bool: z.boolean().optional(),
+});
+
+export const TodoPutBodySchema = z.union([
+  z.object({ id: z.string(), bool: z.boolean() }),
+  z.object({ id: z.string(), text: z.string(), status: z.string() }),
+  z.object({
+    type: z.literal('restatus'),
+    data: z.object({ oldStatus: z.string(), status: z.string() }),
+  }),
+]);
+
+export const TodoDeleteBodySchema = z.object({ id: z.string().min(1) });
+
+// === リストリクエストボディスキーマ ===
+export const ListPostBodySchema = z.object({
+  category: z.string(),
+  number: z.number(),
+});
+
+export const ListPutBodySchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('reorder'),
+    data: z.array(z.string()),
+  }),
+  z.object({
+    type: z.literal('update'),
+    id: z.string(),
+    data: z.object({ category: z.string().optional() }),
+  }),
+]);
+
+export const ListDeleteBodySchema = z.object({ id: z.string().min(1) });
+
+// === Firestore ドキュメントデータスキーマ ===
+export const TodoFirestoreDocSchema = z.object({
+  updateTime: z.instanceof(Timestamp),
+  createdTime: z.instanceof(Timestamp),
+  text: z.string(),
+  status: z.string(),
+  bool: z.boolean(),
+});
+
+export const StatusListFirestoreDocSchema = z.object({
+  category: z.string(),
+  number: z.number(),
+});
+
+export const AdminUserFirestoreDocSchema = z.object({
+  email: z.string(),
+  role: z.enum(['ADMIN', 'USER']),
+  createdAt: z.instanceof(Timestamp),
+  name: z.string().optional(),
+  image: z.string().optional(),
+  updatedAt: z.instanceof(Timestamp).optional(),
 });


### PR DESCRIPTION
## 概要

`.claude/rules/app.md` の「Zodスキーマ: 全リクエスト/レスポンスでバリデーション必須」規約に従い、未対応だった全 API ルートに Zod バリデーションを導入しました。合わせてコードレビューで検出した High 問題 2件も修正しています。

Closes #123

## 主な変更点

### スキーマ追加（`data/validatedData.ts`）

- `TodoPostBodySchema` / `TodoPutBodySchema` / `TodoDeleteBodySchema` — タスク API のリクエストボディ検証
- `ListPostBodySchema` / `ListPutBodySchema` / `ListDeleteBodySchema` — リスト API のリクエストボディ検証
- `TodoFirestoreDocSchema` / `StatusListFirestoreDocSchema` / `AdminUserFirestoreDocSchema` — Firestore ドキュメントデータ検証

### API ルート更新（8ファイル）

| ファイル | 変更内容 |
|---|---|
| `(general)/todos/route.ts` | POST/PUT/DELETE に `safeParse` 追加、GET の `as` キャストを Zod parse に置換 |
| `(general)/lists/route.ts` | 同上 |
| `(general)/user/route.ts` | Firestore data の `as` キャストを Zod parse に置換 |
| `(admin)/users/route.ts` | 同上 |
| `(admin)/users/[userId]/route.ts` | 同上 |
| `(admin)/users/[userId]/todos/route.ts` | 同上 |
| `(admin)/users/[userId]/lists/route.ts` | 同上 |

### バグ修正（コードレビュー High 対応）

- **GET `.map()` 内の throw → skip+warn に変更**: 1件の不正 Firestore ドキュメントが全件取得を永続的に 500 にする問題を修正。不正ドキュメントをスキップし、正常なドキュメントは引き続き返す
- **空文字 id の回帰修正**: `TodoDeleteBodySchema` / `ListDeleteBodySchema` に `.min(1)` を追加。旧コードの falsy ガード（`!id`）削除により `id: ""` が Zod を通過して Firestore SDK が throw → 500 になる回帰を修正

## 関連 Issue

Closes #123

## スクリーンショット（必要に応じて）

なし（API ルートのみの変更）

## 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] 💄 UI/スタイル変更 (UI/Style changes)
- [ ] ⚡ パフォーマンス改善 (Performance improvement)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 📝 ドキュメント更新 (Documentation)
- [ ] 🧪 テスト追加・修正 (Tests)
- [ ] 🔧 設定・ツール変更 (Configuration/Tools)
- [ ] 🚀 デプロイ・インフラ (Deploy/Infrastructure)

## テスト

- [x] ユニットテスト実行済み (`npm run test`) — 497件パス
- [ ] 統合テスト実行済み (`npm run docker:test:run`) — Docker 環境で要実行
- [ ] E2E テスト実行済み (`npm run docker:e2e:run`)
- [x] Lint/Format 実行済み (`npm run format`)

## チェックリスト

- [x] コードレビューの準備ができている
- [ ] 関連するドキュメントを更新した
- [ ] 破壊的変更がある場合、適切に文書化した
- [x] セキュリティ上の問題がないことを確認した
- [x] 既存のテストが通ることを確認した
- [x] コーディングガイドラインに従っている
- [ ] 動作確認済み（主要ブラウザ・画面サイズも確認）
- [ ] 警告が発生していない
- [x] console.log や debugger が残っていない
- [x] 機密情報や API キーが含まれていない
- [ ] 不要な再レンダリングが発生していない（useMemo や useCallback など使用検討）
- [x] 冗長なコードを避け、関数やコンポーネントを再利用している
- [ ] ドキュメントが更新されている（必要に応じて）
- [x] PR の説明が分かりやすく書かれている

## 追加の注意事項

### コードレビュー残課題（Medium / Low）

| 重要度 | 内容 | 対応方針 |
|---|---|---|
| Medium | `TodoPutBodySchema` が `z.union`（first-match）のため `{ id, bool, text, status }` を送ると text/status が無音で消える | 現クライアントは該当ペイロードを送らないため影響なし。後続 Issue で `z.discriminatedUnion` への変更を検討 |
| Medium | `(admin)/users/route.ts` で不正ドキュメントをスキップする際、ユーザーが一覧から非表示になる | skip+warn パターンに変更済み。ログで追跡可能 |
| Low | `data/validatedData.ts` が `firebase-admin/firestore` をトップレベルで import → 将来 Edge Runtime からの誤 import リスク | 現時点で直接の被害なし。Firestore スキーマを別ファイルへの分離は将来検討 |
| Low | `ListPutBodySchema` update 変種の `category` が `z.string().optional()` — スキーマとビジネスルールの不一致 | 手動ガードで補完済み。スキーマ側を `.min(1)` に変更するのは次 PR で対応 |

### Pipeline Log

- Phase 4 Quality Gate: ✓ PASS（format / test 497件 / build）
- Phase 5 Code Review: Critical 0 / High 2（修正済）/ Medium 2 / Low 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

**Bug Fixes**
- 不正なデータがレスポンスに混入しないよう、データ取得時に検証・不正レコードをログ出力して除外するよう改善しました。
- 不正なリクエストは明確なエラー（400/500）で応答するようになり、APIの安定性とエラーメッセージが向上しました。

**New Features**
- 作成/更新/削除リクエストの入力検証を導入し、各操作の信頼性を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sakatai11/todoApp-next/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->