### PR TITLE
fix: react-doctor アクションを安定版に固定しCI失敗を解消

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   react-doctor:
@@ -21,7 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: millionco/react-doctor@main
+      # `@main` は action.yml と CLI（version 既定: latest）が共に流動するため、
+      # 上流の更新で CI が不安定化する。アクションは安定版タグ、CLI は固定
+      # バージョンにピン留めして再現性を確保する。
+      - uses: millionco/react-doctor@v2.1.0
         with:
-          diff: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: '0.5.1'

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -25,6 +25,6 @@ jobs:
       # `@main` は action.yml と CLI（version 既定: latest）が共に流動するため、
       # 上流の更新で CI が不安定化する。アクションは安定版タグ、CLI は固定
       # バージョンにピン留めして再現性を確保する。
-      - uses: millionco/react-doctor@v2.1.0
+      - uses: millionco/react-doctor@547e1e4ecdb70315d81a91ec3605701d58616ee2 # v2.1.0
         with:
           version: '0.5.1'


### PR DESCRIPTION
## 概要

React Doctor CI が `error: too many arguments. Expected 1 argument but got 2.`（`SCAN_EXIT: 1`）でクラッシュし失敗する問題を修正します。

## 原因

`millionco/react-doctor@main` は **アクション定義（action.yml）と CLI（`version` 既定値: `latest`）が共に流動**するため、上流の更新で CI が不安定化していました。

- **6/9（#156, スキルのみの変更）は success / 6/10 は同一内容で 3 回連続 failure** → コード差分ではなく `@main` の更新が原因（日付相関）。
- リポジトリの変更内容（markdown / shell のみ）とは無関係。

## 修正内容

- アクションを `@main` → **`@v2.1.0`（安定版タグ）** に固定
- CLI を **`version: '0.5.1'`** に固定し、floating な `latest` を排除
- 現行アクションに存在しない無効な入力 `diff: main` / `github-token` を削除
- commit-status 公開時の `Requires authentication` 警告を解消するため `statuses: write` 権限を追加

## 検証

- 本 PR の React Doctor チェックが green になることで確認（CI 実行で検証）

## 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 設定・ツール変更 (Configuration/Tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD ワークフローの安定性向上のため、依存ツールのバージョンをメインブランチの変動可能なバージョンから固定バージョンに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->