### PR TITLE
test: P1対応 リスト並び替えロールバックの検証強化 (#147)

### DIFF
--- a/tests/features/todo/hooks/useLists.test.ts
+++ b/tests/features/todo/hooks/useLists.test.ts
@@ -316,7 +316,7 @@ describe('useLists', () => {
       expect(mockApiRequest).not.toHaveBeenCalled();
     });
 
-    it('API呼び出しが失敗してもクライアント側の更新は実行される', async () => {
+    it('API呼び出しが失敗した場合、listsがロールバックされエラーが通知される', async () => {
       const consoleSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
@@ -325,13 +325,23 @@ describe('useLists', () => {
 
       const { result } = renderHook(() => useLists(mockInitialLists));
 
+      // 操作前のlistsを保持（ロールバック先の検証用）
+      const listsBefore = result.current.lists;
+
       const dragEvent = createMockDragEvent('list-1', 'list-3');
 
       await act(async () => {
         await result.current.handleDragEnd(dragEvent);
       });
 
+      // 楽観的更新は試みられる
       expect(mockArrayMove).toHaveBeenCalled();
+      // 失敗時は操作前の状態にロールバックされる
+      expect(result.current.lists).toEqual(listsBefore);
+      // エラーが通知される
+      expect(mockShowError).toHaveBeenCalledWith(
+        ERROR_MESSAGES.LIST.SORT_FAILED,
+      );
 
       consoleSpy.mockRestore();
     });
@@ -431,7 +441,7 @@ describe('useLists', () => {
       expect(mockApiRequest).not.toHaveBeenCalled();
     });
 
-    it('API呼び出しが失敗してもクライアント側の更新は実行される', async () => {
+    it('API呼び出しが失敗した場合、listsがロールバックされエラーが通知される', async () => {
       const consoleSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
@@ -440,11 +450,21 @@ describe('useLists', () => {
 
       const { result } = renderHook(() => useLists(mockInitialLists));
 
+      // 操作前のlistsを保持（ロールバック先の検証用）
+      const listsBefore = result.current.lists;
+
       await act(async () => {
         await result.current.handleButtonMove('list-1', 'right');
       });
 
+      // 楽観的更新は試みられる
       expect(mockArrayMove).toHaveBeenCalled();
+      // 失敗時は操作前の状態にロールバックされる
+      expect(result.current.lists).toEqual(listsBefore);
+      // エラーが通知される
+      expect(mockShowError).toHaveBeenCalledWith(
+        ERROR_MESSAGES.LIST.MOVE_FAILED,
+      );
 
       consoleSpy.mockRestore();
     });


### PR DESCRIPTION
## 概要

Issue #155 P1 のテスト系のうち、#147（リスト並び替えロールバックの未検証）を対応する。

## 対応Issue

- Closes #147 リスト並び替えのロールバックが未検証（見かけだけのカバレッジ）

## 変更内容

### `tests/features/todo/hooks/useLists.test.ts`
`handleDragEnd` / `handleButtonMove` の失敗系テストは従来 `expect(mockArrayMove).toHaveBeenCalled()` のみを検証しており、実装のロールバック処理（`setLists(previousLists)` + `showError`）を削除しても緑のまま通過する「見かけだけのカバレッジ」だった。以下を検証するよう修正:

- **handleDragEnd 失敗時**: `result.current.lists` が操作前（`listsBefore`）に等しい（ロールバック）／`showError(LIST.SORT_FAILED)` 呼び出し
- **handleButtonMove 失敗時**: `result.current.lists` が操作前に等しい／`showError(LIST.MOVE_FAILED)` 呼び出し
- テスト名を実装挙動（ロールバックする）に合わせて修正

### 退行検出能力（verifier確認済み）
- catch の `setLists(previousLists)` を削除すると、楽観的更新後の並び替え済み配列が残り `toEqual(listsBefore)` が赤になる
- `showError(...)` を削除すると `toHaveBeenCalledWith` が赤になる

## テスト

- `useLists.test.ts`: 全パス（25件）

## 補足: #148 は本PRに含めない

#148（コアTodoフローE2E）は同じP1テスト系だが、実行検証に Docker スタック（`localhost:3000` + Firebase Emulator + seed）の起動が必須で、本サイクルでは検証不可。未検証のE2EはCI破壊リスクがあるため、`.claude/state/triage-inbox.md` に人間判断待ちとして記録し本PRから分離した。

---

Generated by todoapp-backlog-loop

- item_id: issue:147
- creator: todoapp-backlog-loop（creator直接実装）
- verifier verdict: pass
- Critical/High: 0
- Medium/Low notes:
  - Medium: `useLists.test.ts` の既存テスト説明文に「正しく」が複数残存（本PR変更外。表記規約上は「正常に」）
  - Low: `mockApiRequest` の `as unknown as ReturnType<typeof vi.fn>` 二重キャスト（既存）
