### PR TITLE
feat: 非同期操作中のボタン無効化とローディング表示を追加 (#151)

### DIFF
--- a/features/todo/components/elements/Add/AddList.tsx
+++ b/features/todo/components/elements/Add/AddList.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useTodoContext } from '@/features/todo/contexts/TodoContext';
-import { Button, TextField, Box } from '@mui/material';
+import { Button, TextField, Box, CircularProgress } from '@mui/material';
 import AddBoxIcon from '@mui/icons-material/AddBox';
 
 const AddList = () => {
@@ -10,13 +10,21 @@ const AddList = () => {
     listHooks;
 
   const [addBtn, setAddBtn] = useState(false);
+  // 送信中フラグ（二重送信防止・ローディング表示）
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleAddList = async () => {
-    const errorFlag = await addList();
-    if (errorFlag) {
-      setAddBtn(false);
-    } else {
-      setAddBtn(true);
+    // 送信中は disabled でクリックが抑止されるため、ここでのガードは不要
+    setIsSubmitting(true);
+    try {
+      const errorFlag = await addList();
+      if (errorFlag) {
+        setAddBtn(false);
+      } else {
+        setAddBtn(true);
+      }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -51,7 +59,17 @@ const AddList = () => {
               gap: '12px',
             }}
           >
-            <Button variant="outlined" fullWidth onClick={handleAddList}>
+            <Button
+              variant="outlined"
+              fullWidth
+              onClick={handleAddList}
+              disabled={isSubmitting}
+              startIcon={
+                isSubmitting ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : undefined
+              }
+            >
               追加する
             </Button>
             <Button

--- a/features/todo/components/elements/Add/AddList.tsx
+++ b/features/todo/components/elements/Add/AddList.tsx
@@ -17,11 +17,9 @@ const AddList = () => {
     // 送信中は disabled でクリックが抑止されるため、ここでのガードは不要
     setIsSubmitting(true);
     try {
-      const errorFlag = await addList();
-      if (errorFlag) {
+      const isSuccess = await addList();
+      if (isSuccess) {
         setAddBtn(false);
-      } else {
-        setAddBtn(true);
       }
     } finally {
       setIsSubmitting(false);

--- a/features/todo/components/elements/Add/AddTodo.tsx
+++ b/features/todo/components/elements/Add/AddTodo.tsx
@@ -1,6 +1,7 @@
 'use client';
+import { useState } from 'react';
 import { useTodoContext } from '@/features/todo/contexts/TodoContext';
-import { Button, TextField, Box } from '@mui/material';
+import { Button, TextField, Box, CircularProgress } from '@mui/material';
 import AddBoxIcon from '@mui/icons-material/AddBox';
 
 type AddTodoProps = {
@@ -19,16 +20,25 @@ const AddTodo = ({ status }: AddTodoProps) => {
     setAddTodoOpenStatus,
   } = todoHooks;
 
+  // 送信中フラグ（二重送信防止・ローディング表示）
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   // このAddTodoコンポーネントが開いているかどうかを判定
   const isOpen = addTodoOpenStatus === status;
 
   const handleAddTodo = async () => {
-    const errorFlag = await addTodo();
-    if (errorFlag) {
-      // 成功した場合は閉じる
-      setAddTodoOpenStatus(null);
+    // 送信中は disabled でクリックが抑止されるため、ここでのガードは不要
+    setIsSubmitting(true);
+    try {
+      const errorFlag = await addTodo();
+      if (errorFlag) {
+        // 成功した場合は閉じる
+        setAddTodoOpenStatus(null);
+      }
+      // エラーの場合は開いたままにする
+    } finally {
+      setIsSubmitting(false);
     }
-    // エラーの場合は開いたままにする
   };
 
   return (
@@ -67,7 +77,17 @@ const AddTodo = ({ status }: AddTodoProps) => {
               gap: '12px',
             }}
           >
-            <Button variant="outlined" fullWidth onClick={handleAddTodo}>
+            <Button
+              variant="outlined"
+              fullWidth
+              onClick={handleAddTodo}
+              disabled={isSubmitting}
+              startIcon={
+                isSubmitting ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : undefined
+              }
+            >
               追加する
             </Button>
             <Button

--- a/features/todo/components/elements/Modal/DeleteModal.tsx
+++ b/features/todo/components/elements/Modal/DeleteModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button, Box, Typography, IconButton } from '@mui/material';
 import Modal from '@mui/material/Modal';
 import CloseIcon from '@mui/icons-material/Close';
@@ -10,6 +11,9 @@ const DeleteModal = ({
   setModalIsOpen,
   setSelectModalIsOpen,
 }: DeletePropType) => {
+  // 送信中フラグ（二重送信防止・ローディング表示）
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   return (
     <>
       <Modal //モーダル
@@ -77,7 +81,11 @@ const DeleteModal = ({
               <Button
                 variant="contained"
                 sx={{ maxWidth: '120px ', width: '100%' }}
+                disabled={isSubmitting}
                 onClick={() => {
+                  // 削除は楽観的更新で即時実行されモーダルがアンマウントされるため、
+                  // disabled により連打での重複リクエストを防止する
+                  setIsSubmitting(true);
                   onDelete();
                   if (setSelectModalIsOpen) {
                     setSelectModalIsOpen(false);

--- a/features/todo/components/elements/Modal/EditModal.tsx
+++ b/features/todo/components/elements/Modal/EditModal.tsx
@@ -1,5 +1,12 @@
-import React, { useCallback } from 'react';
-import { Button, Box, Typography, TextField, IconButton } from '@mui/material';
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  Box,
+  Typography,
+  TextField,
+  IconButton,
+  CircularProgress,
+} from '@mui/material';
 import { ModalPropType } from '@/types/components';
 import { jstFormattedDate, getTime } from '@/features/utils/dateUtils';
 import Modal from '@mui/material/Modal';
@@ -24,6 +31,9 @@ const EditModal = React.memo(
     const statusPull = listHooks.lists;
     const isPushContainer = id === 'pushContainer' ? true : false;
 
+    // 送信中フラグ（二重送信防止・ローディング表示）
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
     const handleClose = useCallback(() => {
       setModalIsOpen(false);
       setValidationError({ listPushArea: false, listModalArea: false }); // バリデーションエラーリセット
@@ -32,15 +42,21 @@ const EditModal = React.memo(
     }, [setModalIsOpen, setValidationError, setEditId, setInput]);
 
     const handleSubmit = useCallback(async () => {
-      let success = false;
-      if (isPushContainer) {
-        success = await addTodo();
-      } else {
-        success = await saveTodo();
-      }
+      // 送信中は disabled でクリックが抑止されるため、ここでのガードは不要
+      setIsSubmitting(true);
+      try {
+        let success = false;
+        if (isPushContainer) {
+          success = await addTodo();
+        } else {
+          success = await saveTodo();
+        }
 
-      if (success) {
-        setModalIsOpen(false);
+        if (success) {
+          setModalIsOpen(false);
+        }
+      } finally {
+        setIsSubmitting(false);
       }
     }, [isPushContainer, addTodo, saveTodo, setModalIsOpen]);
 
@@ -158,6 +174,12 @@ const EditModal = React.memo(
                 variant="contained"
                 sx={{ display: 'block' }}
                 onClick={handleSubmit}
+                disabled={isSubmitting}
+                startIcon={
+                  isSubmitting ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : undefined
+                }
               >
                 {isPushContainer ? '追加' : '保存'}
               </Button>

--- a/tests/features/todo/components/elements/Add/AddList.test.tsx
+++ b/tests/features/todo/components/elements/Add/AddList.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/tests/test-utils';
+import { render, screen, fireEvent, waitFor, within } from '@/tests/test-utils';
 import AddList from '@/features/todo/components/elements/Add/AddList';
+import { http, HttpResponse, delay } from 'msw';
+import { server } from '@/todoApp-submodule/mocks/server';
 
 describe('AddList', () => {
   beforeEach(() => {
@@ -345,6 +347,78 @@ describe('AddList', () => {
           screen.getByText('同じリスト名が存在します'),
         ).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('二重送信防止・ローディング表示', () => {
+    it('送信中はボタンが無効化されローディングが表示される', async () => {
+      server.use(
+        http.post('/api/lists', async () => {
+          await delay(50);
+          return HttpResponse.json(
+            { id: 'list-loading', category: 'Unique List', number: 99 },
+            { status: 200 },
+          );
+        }),
+      );
+
+      render(<AddList />, { withTodoProvider: true });
+      fireEvent.click(
+        screen.getByRole('button', { name: /リストを追加する/i }),
+      );
+      fireEvent.change(screen.getByLabelText('リスト名を入力'), {
+        target: { value: 'Unique List' },
+      });
+
+      const submitButton = screen.getByRole('button', { name: '追加する' });
+      fireEvent.click(submitButton);
+
+      // 送信中はボタンが無効化され、スピナーが表示される
+      expect(submitButton).toBeDisabled();
+      expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
+
+      // 成功後はフォームが閉じる
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /リストを追加する/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('送信中に再クリックしても重複リクエストが送信されない', async () => {
+      let postCount = 0;
+      server.use(
+        http.post('/api/lists', async () => {
+          postCount += 1;
+          await delay(50);
+          return HttpResponse.json(
+            { id: 'list-dup', category: 'Unique List', number: 99 },
+            { status: 200 },
+          );
+        }),
+      );
+
+      render(<AddList />, { withTodoProvider: true });
+      fireEvent.click(
+        screen.getByRole('button', { name: /リストを追加する/i }),
+      );
+      fireEvent.change(screen.getByLabelText('リスト名を入力'), {
+        target: { value: 'Unique List' },
+      });
+
+      const submitButton = screen.getByRole('button', { name: '追加する' });
+      // 連打
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /リストを追加する/i }),
+        ).toBeInTheDocument();
+      });
+
+      expect(postCount).toBe(1);
     });
   });
 });

--- a/tests/features/todo/components/elements/Add/AddList.test.tsx
+++ b/tests/features/todo/components/elements/Add/AddList.test.tsx
@@ -420,5 +420,35 @@ describe('AddList', () => {
 
       expect(postCount).toBe(1);
     });
+
+    it('送信失敗前に戻った場合はフォームを再表示しない', async () => {
+      server.use(
+        http.post('/api/lists', async () => {
+          await delay(50);
+          return HttpResponse.json(
+            { error: 'Internal Server Error' },
+            { status: 500 },
+          );
+        }),
+      );
+
+      render(<AddList />, { withTodoProvider: true });
+      fireEvent.click(
+        screen.getByRole('button', { name: /リストを追加する/i }),
+      );
+      fireEvent.change(screen.getByLabelText('リスト名を入力'), {
+        target: { value: 'Failure List' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: '追加する' }));
+      fireEvent.click(screen.getByRole('button', { name: '戻る' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /リストを追加する/i }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText('リスト名を入力')).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/features/todo/components/elements/Add/AddTodo.test.tsx
+++ b/tests/features/todo/components/elements/Add/AddTodo.test.tsx
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent, act } from '@/tests/test-utils';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  within,
+} from '@/tests/test-utils';
 import AddTodo from '@/features/todo/components/elements/Add/AddTodo';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse, delay } from 'msw';
+import { server } from '@/todoApp-submodule/mocks/server';
 
 describe('AddTodo', () => {
   const defaultProps = {
@@ -261,6 +270,86 @@ describe('AddTodo', () => {
 
       rerender(<AddTodo status="completed" />);
       expect(screen.getByText('TODOを追加する')).toBeInTheDocument();
+    });
+  });
+
+  describe('二重送信防止・ローディング表示', () => {
+    it('送信中はボタンが無効化されローディングが表示される', async () => {
+      server.use(
+        http.post('/api/todos', async () => {
+          await delay(50);
+          const currentTime = new Date().toISOString();
+          return HttpResponse.json(
+            {
+              id: 'todo-loading',
+              text: 'New Todo',
+              status: 'pending',
+              bool: false,
+              createdTime: currentTime,
+              updateTime: currentTime,
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      const user = userEvent.setup();
+      render(<AddTodo status="pending" />);
+
+      await user.click(screen.getByText('TODOを追加する'));
+      await user.type(screen.getByLabelText('TODOを入力'), 'New Todo');
+
+      const submitButton = screen.getByRole('button', { name: '追加する' });
+      fireEvent.click(submitButton);
+
+      // 送信中はボタンが無効化され、スピナーが表示される
+      expect(submitButton).toBeDisabled();
+      expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
+
+      // 成功後は入力モードが閉じる
+      await waitFor(() => {
+        expect(screen.getByText('TODOを追加する')).toBeInTheDocument();
+      });
+    });
+
+    it('送信中に再クリックしても重複リクエストが送信されない', async () => {
+      let postCount = 0;
+      server.use(
+        http.post('/api/todos', async () => {
+          postCount += 1;
+          await delay(50);
+          const currentTime = new Date().toISOString();
+          return HttpResponse.json(
+            {
+              id: 'todo-dup',
+              text: 'New Todo',
+              status: 'pending',
+              bool: false,
+              createdTime: currentTime,
+              updateTime: currentTime,
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      const user = userEvent.setup();
+      render(<AddTodo status="pending" />);
+
+      await user.click(screen.getByText('TODOを追加する'));
+      await user.type(screen.getByLabelText('TODOを入力'), 'New Todo');
+
+      const submitButton = screen.getByRole('button', { name: '追加する' });
+      // 連打
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('TODOを追加する')).toBeInTheDocument();
+      });
+
+      expect(postCount).toBe(1);
     });
   });
 });

--- a/tests/features/todo/components/elements/Modal/DeleteModal.test.tsx
+++ b/tests/features/todo/components/elements/Modal/DeleteModal.test.tsx
@@ -248,7 +248,7 @@ describe('DeleteModal', () => {
   });
 
   describe('エッジケース', () => {
-    it('複数回のボタンクリックが正常に処理される', () => {
+    it('OKボタンを連打しても重複してonDeleteが呼ばれない', () => {
       const mockOnDelete = vi.fn();
       const mockSetModalIsOpen = vi.fn();
       render(
@@ -261,9 +261,12 @@ describe('DeleteModal', () => {
 
       const okButton = screen.getByRole('button', { name: 'OK' });
       fireEvent.click(okButton);
+      // 送信中はボタンが無効化されるため、連打しても重複実行されない
+      fireEvent.click(okButton);
       fireEvent.click(okButton);
 
-      expect(mockOnDelete).toHaveBeenCalledTimes(2);
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+      expect(okButton).toBeDisabled();
     });
 
     it('同時に複数のボタンクリックが処理される', () => {

--- a/tests/features/todo/components/elements/Modal/EditModal.test.tsx
+++ b/tests/features/todo/components/elements/Modal/EditModal.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@/tests/test-utils';
+import { render, screen, fireEvent, waitFor, within } from '@/tests/test-utils';
 import EditModal from '@/features/todo/components/elements/Modal/EditModal';
 import { mockTodos } from '@/tests/test-utils';
 import { Timestamp } from 'firebase-admin/firestore';
+import { http, HttpResponse, delay } from 'msw';
+import { server } from '@/todoApp-submodule/mocks/server';
 
 // StatusPullListをモック
 vi.mock('@/features/todo/components/elements/Status/StatusPullList', () => ({
@@ -540,6 +542,105 @@ describe('EditModal', () => {
 
       // ボタンの基本動作を確認
       expect(saveButton).toBeInTheDocument();
+    });
+  });
+
+  describe('二重送信防止・ローディング表示', () => {
+    it('送信中はボタンが無効化されローディングが表示される', async () => {
+      server.use(
+        http.post('/api/todos', async () => {
+          await delay(50);
+          const currentTime = new Date().toISOString();
+          return HttpResponse.json(
+            {
+              id: 'todo-loading',
+              text: 'New Item',
+              status: 'todo',
+              bool: false,
+              createdTime: currentTime,
+              updateTime: currentTime,
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      render(<EditModal {...defaultProps} id="pushContainer" />, {
+        withTodoProvider: true,
+      });
+
+      // 本文とステータスを入力
+      fireEvent.change(screen.getByDisplayValue(''), {
+        target: { value: 'New Item' },
+      });
+      fireEvent.change(screen.getByTestId('status-select'), {
+        target: { value: 'todo' },
+      });
+
+      const submitButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(submitButton);
+
+      // 送信中はボタンが無効化され、スピナーが表示される
+      expect(submitButton).toBeDisabled();
+      expect(within(submitButton).getByRole('progressbar')).toBeInTheDocument();
+
+      // 完了後はボタンが再び有効化される
+      await waitFor(() => {
+        expect(submitButton).not.toBeDisabled();
+      });
+    });
+
+    it('送信中に再クリックしても重複リクエストが送信されない', async () => {
+      let postCount = 0;
+      server.use(
+        http.post('/api/todos', async () => {
+          postCount += 1;
+          await delay(50);
+          const currentTime = new Date().toISOString();
+          return HttpResponse.json(
+            {
+              id: 'todo-dup',
+              text: 'New Item',
+              status: 'todo',
+              bool: false,
+              createdTime: currentTime,
+              updateTime: currentTime,
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      const mockSetModalIsOpen = vi.fn();
+      render(
+        <EditModal
+          {...defaultProps}
+          id="pushContainer"
+          setModalIsOpen={mockSetModalIsOpen}
+        />,
+        {
+          withTodoProvider: true,
+        },
+      );
+
+      fireEvent.change(screen.getByDisplayValue(''), {
+        target: { value: 'New Item' },
+      });
+      fireEvent.change(screen.getByTestId('status-select'), {
+        target: { value: 'todo' },
+      });
+
+      const submitButton = screen.getByRole('button', { name: '追加' });
+      // 連打
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockSetModalIsOpen).toHaveBeenCalledWith(false);
+      });
+
+      expect(postCount).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## 概要

非同期操作中（Todo追加・保存・リスト追加・リスト/Todo削除）に確認ボタンを無効化し、ローディング表示を追加することで、連打による重複リクエストを防止します。Issue #151 対応。

## 主な変更点

- **AddTodo / AddList / EditModal**: ローカル `isSubmitting` state を追加し、送信ハンドラを `try/finally` でラップ。送信中は確認ボタンを `disabled` にし、`CircularProgress` を `startIcon` で表示。`finally` で確実にフラグをリセット（API失敗時も復帰）。
- **DeleteModal**: OKボタンに `disabled={isSubmitting}` を適用。削除は楽観的更新で即時アンマウントされるためスピナーは付けず、`disabled` による連打防止のみ（キャンセルは操作可能なまま維持）。
- 二重送信防止は HTML の `disabled`（MUI Button は disabled 時 onClick 非発火）に一本化し、冗長な実行時ガードは設けない。
- 各コンポーネントに「送信中の disabled/ローディング表示」「連打で重複リクエストが飛ばない（`postCount === 1`）」のユニットテストを追加。DeleteModal の既存連打テストを重複防止の意図に合わせて更新。

## 関連 Issue

Closes #151

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 💄 UI/スタイル変更 (UI/Style changes)
- [x] 🧪 テスト追加・修正 (Tests)

## テスト

- [x] ユニットテスト実行済み（全510テストパス）
- [x] Lint/Format 実行済み (`npm run format`)
- [ ] 統合テスト（本変更はクライアントUIのみのため対象外）

## 受け入れ条件

- [x] 送信中に再クリックしても重複リクエストが飛ばない
- [x] ローディング中にUIフィードバック（スピナー/disabled）が表示される
- [x] 対象: Todo追加・保存・リスト追加・削除モーダルの確認ボタン

---

Generated by todoapp-backlog-loop

- item_id: issue:151
- creator: todoapp-orchestrator（backlog-loop 直接実行）
- verifier verdict: conditional（frontend-pattern + code-quality の2観点、High修正後に再検証で High/Critical 0 を確認）
- Critical/High: 0
- Medium/Low notes:
  - (Low) DeleteModal の `isSubmitting` は楽観的更新によるアンマウントを前提とし `finally` でのリセットを持たない（コメントで明示）。将来 onDelete を非同期化する場合は finally 追加が望ましい
  - (Low) `handleAddTodo` / `handleAddList` は useCallback 未ラップ（既存設計踏襲、スコープ外）
  - (情報) EditModal:157 の型ガード else 分岐はカバレッジ対象外だが本変更前から存在する既存コード


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * リスト・タスク追加/削除/編集で、送信ボタン連打による二重送信を防止しました。
* **New Features**
  * 送信処理中は追加/確定ボタンを無効化し、プログレスバーを表示するようにしました。
  * 送信完了後のボタン状態を適切に復帰します。
* **Tests**
  * MSW（遅延）を用いたローディング表示・二重送信抑止・挙動の検証を追加・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->