### PR TITLE
feat: リスト0件時の空状態ガイドを追加 (#153)

### DIFF
--- a/features/todo/components/MainContainer/MainContainer.tsx
+++ b/features/todo/components/MainContainer/MainContainer.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { useTodoContext } from '@/features/todo/contexts/TodoContext';
 import { DndContext, closestCenter } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
@@ -28,6 +28,43 @@ const MainContainer = () => {
   const { todoHooks, listHooks } = useTodoContext();
   const { todos } = todoHooks;
   const { lists, handleDragEnd } = listHooks;
+
+  // リストが0件のときは、初回ユーザー向けの空状態ガイドを表示する
+  if (lists.length === 0) {
+    return (
+      <Box
+        sx={{
+          maxWidth: '1660px',
+          paddingTop: '80px',
+          width: '100%',
+          margin: '0 auto',
+        }}
+      >
+        <Stack
+          spacing={2}
+          alignItems="center"
+          sx={{
+            mt: 4,
+            px: 3,
+            textAlign: 'center',
+            '@media (max-width: 767px)': {
+              px: 2,
+            },
+          }}
+        >
+          <Typography variant="h6" component="h2">
+            まだリストがありません
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            最初のリストを作成して、TODO管理を始めましょう。
+          </Typography>
+          <Box sx={{ width: '100%', maxWidth: 320 }}>
+            <AddList />
+          </Box>
+        </Stack>
+      </Box>
+    );
+  }
 
   return (
     <DndContext

--- a/features/todo/components/MainContainer/MainContainer.tsx
+++ b/features/todo/components/MainContainer/MainContainer.tsx
@@ -45,11 +45,8 @@ const MainContainer = () => {
           alignItems="center"
           sx={{
             mt: 4,
-            px: 3,
+            px: { xs: 2, sm: 3 },
             textAlign: 'center',
-            '@media (max-width: 767px)': {
-              px: 2,
-            },
           }}
         >
           <Typography variant="h6" component="h2">

--- a/tests/features/todo/components/MainContainer/MainContainer.test.tsx
+++ b/tests/features/todo/components/MainContainer/MainContainer.test.tsx
@@ -233,7 +233,7 @@ describe('MainContainer', () => {
       }).not.toThrow();
     });
 
-    it('空のリスト配列でも正常に動作する', () => {
+    it('空のリスト配列のときは空状態ガイドを表示しクラッシュしない', () => {
       expect(() => {
         render(<MainContainer />, {
           initialTodos: mockTodos,
@@ -263,6 +263,52 @@ describe('MainContainer', () => {
           initialLists: mockLists,
         });
       }).not.toThrow();
+    });
+  });
+
+  describe('空状態ガイド', () => {
+    it('リスト0件のときに説明的な空状態メッセージが表示される', () => {
+      render(<MainContainer />, {
+        initialTodos: [],
+        initialLists: [],
+      });
+
+      expect(screen.getByText('まだリストがありません')).toBeInTheDocument();
+      expect(
+        screen.getByText('最初のリストを作成して、TODO管理を始めましょう。'),
+      ).toBeInTheDocument();
+    });
+
+    it('リスト0件のときにリスト作成への導線が表示される', () => {
+      render(<MainContainer />, {
+        initialTodos: [],
+        initialLists: [],
+      });
+
+      expect(
+        screen.getByRole('button', { name: /リストを追加する/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('リスト0件のときは通常のダッシュボード（DnD）は表示されない', () => {
+      render(<MainContainer />, {
+        initialTodos: [],
+        initialLists: [],
+      });
+
+      expect(screen.queryByTestId('dnd-context')).not.toBeInTheDocument();
+    });
+
+    it('リストが存在するときは空状態メッセージが表示されない', () => {
+      render(<MainContainer />, {
+        initialTodos: mockTodos,
+        initialLists: mockLists,
+      });
+
+      expect(
+        screen.queryByText('まだリストがありません'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('dnd-context')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## 概要

リストが0件のとき、ダッシュボードに説明的な空状態ガイド（案内メッセージ + リスト作成への明確な導線）を表示します。初回ユーザーが何をすべきか分かるようにします。Issue #153 対応。

## 主な変更点

- **MainContainer**: `lists.length === 0` のとき early return で空状態ガイドを表示。
  - `Stack` + `Typography` で「まだリストがありません」「最初のリストを作成して、TODO管理を始めましょう。」を中央表示。
  - CTA は既存の `AddList` コンポーネントを再利用（新たな状態・API・フックは追加しない）。
- リストが1件以上になると `lists.length === 0` 条件が外れ、従来の DnD ダッシュボードが自動描画される（追加後の遷移は既存フローのまま）。
- 空状態の表示/非表示・作成導線のユニットテストを追加。

## 関連 Issue

Closes #153

## スクリーンショット（必要に応じて）

<!-- リスト0件時の空状態ガイド -->

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 💄 UI/スタイル変更 (UI/Style changes)
- [x] 🧪 テスト追加・修正 (Tests)

## テスト

- [x] ユニットテスト実行済み（MainContainer 19テストパス / 全体パス、対象カバレッジ100%）
- [x] Lint/Format 実行済み (`npm run format`)
- [ ] 統合テスト（クライアントUIのみのため対象外）

## 受け入れ条件

- [x] `lists.length === 0` 時に説明的な空状態メッセージが表示される
- [x] リスト作成への明確な導線がある（AddList）
- [x] 追加後は通常のダッシュボードに遷移する（既存追加フロー不変）

---

Generated by todoapp-backlog-loop

- item_id: issue:153
- creator: todoapp-orchestrator（backlog-loop 直接実行）
- verifier verdict: conditional（frontend-pattern + accessibility の2観点、ともに Critical/High 0）
- Critical/High: 0
- Medium/Low notes:
  - (frontend Medium・対応済み) 上部余白の二重指定を `mt: 4` に調整し通常レイアウトと整合
  - (frontend Medium・対応済み) 既存テスト名を空状態ガイド表示の意図に合わせて改訂
  - (a11y Medium・既知/スコープ外) `AddList` の `TextField` は固定 id `outlined-basic` を使用。空状態と通常表示は排他描画のため同一ページ内で重複せず実害なし。将来 id をユニーク化することが望ましい
  - (a11y Low) `text.secondary` のコントラストは MUI デフォルトテーマで AA 達成。カスタムテーマ導入時は要再検証


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* リストが0件のとき、初回ユーザー向けのガイドメッセージとリスト作成ボタンを表示するようになりました。

## テスト
* 空状態表示の正確性、ガイドメッセージの表示、リスト作成ボタンの動作、ドラッグ&ドロップ機能の適切な表示・非表示を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->