### PR TITLE
docs: worktree isolation の起点ブランチ不具合と回避策を development.md に追記

### DIFF
--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -253,6 +253,22 @@ Task({ isolation: "worktree", ... })
 Task({ isolation: "worktree", ... })
 ```
 
+### ⚠️ 既知の不具合：worktree の起点ブランチ
+
+`isolation: "worktree"` はリポジトリの **default branch**（`main`）を起点にする。
+このプロジェクトでは開発ブランチが `develop-v2` のため、**worktree 内のベースが古い main コミットになり差分が壊れる**。
+
+**対処法（worktree を使いたい場合）**:
+
+```bash
+# worktree 内で必ず develop-v2 を起点にリベースする
+git fetch origin develop-v2
+git rebase origin/develop-v2
+```
+
+あるいは worktree を使わず、**主ツリーで `develop-v2` から手動でブランチを切って逐次実装する**。
+`todoapp-backlog-loop` スキルでは後者（主ツリー逐次）を優先する。
+
 ### Worktreeを使わない場合
 
 以下はWorktreeなしで通常実行する：
@@ -260,6 +276,7 @@ Task({ isolation: "worktree", ... })
 - 単一タスクの実装・修正
 - 既存コードの調査・読み取りのみ
 - ユニットテスト（MSWモードで動作するため Docker 不要）
+- `develop-v2` が default branch でない間の並列実装（worktree 起点問題を避けるため）
 
 ## Git ワークフロー
 

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -261,9 +261,9 @@ Task({ isolation: "worktree", ... })
 **対処法（worktree を使いたい場合）**:
 
 ```bash
-# worktree 内で必ず develop-v2 を起点にリベースする
+# worktree 内で必ず develop-v2 を起点にリセットする
 git fetch origin develop-v2
-git rebase origin/develop-v2
+git reset --hard origin/develop-v2
 ```
 
 あるいは worktree を使わず、**主ツリーで `develop-v2` から手動でブランチを切って逐次実装する**。


### PR DESCRIPTION
## Summary

- `isolation: \"worktree\"` が default branch（`main`）起点になる既知の不具合を `development.md` に明記
- 回避策として2つの選択肢を記載
  1. worktree 内で `git rebase origin/develop-v2` する手順
  2. worktree を使わず主ツリーで `develop-v2` から手動ブランチを切る逐次実装（`todoapp-backlog-loop` スキルではこちらを優先）
- 「Worktreeを使わない場合」の例に `develop-v2` が default branch でない期間を追加

## 背景

`#155` 対応サイクル（#151 → PR #167、#153 → PR #168）において、`loop-creator` サブエージェントを `isolation: \"worktree\"` で呼び出した際に worktree のベースが旧 `main`（13e31b9）になり差分が壊れる事象が発生。
結果として worktree 経由の委譲を断念し主ツリーで逐次実装した。
同じ落とし穴を繰り返さないためドキュメントに残す。

## Test plan

- [x] `.claude/rules/development.md` の「⚠️ 既知の不具合」セクションが追加されていることを確認
- [x] 記載内容（不具合説明・回避手順・スキル方針）が正確であることをレビューで確認

---

Generated by todoapp-backlog-loop

- item_id: docs:worktree-caveat
- creator: backlog-loop(直接実行)
- verifier verdict: n/a（ドキュメントのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 並列実行時の既知の不具合と回避手順をドキュメントに明記しました
  * 開発ガイドラインを更新し、ブランチ構成に関する並列実装時の制限事項を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->