### PR TITLE
fix: server-login の不正ボディを400で統一エラー返却 (#154)

### DIFF
--- a/app/api/auth/server-login/route.ts
+++ b/app/api/auth/server-login/route.ts
@@ -12,7 +12,21 @@ const getFirebaseAdmin = async () => {
 };
 
 export async function POST(req: Request) {
-  const { email, password } = await req.json();
+  let email: string | undefined;
+  let password: string | undefined;
+  try {
+    const body = (await req.json()) as {
+      email?: string;
+      password?: string;
+    };
+    email = body?.email;
+    password = body?.password;
+  } catch {
+    return NextResponse.json(
+      { error: 'リクエストボディが不正です' },
+      { status: 400 },
+    );
+  }
 
   if (!email || !password) {
     return NextResponse.json(

--- a/app/api/auth/server-login/route.ts
+++ b/app/api/auth/server-login/route.ts
@@ -1,6 +1,6 @@
 // api/auth/token/route.ts
 import { NextResponse } from 'next/server';
-import { AuthResponseSchema } from '@/data/validatedData';
+import { AuthResponseSchema, CredentialsSchema } from '@/data/validatedData';
 
 // Dynamic imports to avoid client-side loading
 const getFirebaseAdmin = async () => {
@@ -12,15 +12,9 @@ const getFirebaseAdmin = async () => {
 };
 
 export async function POST(req: Request) {
-  let email: string | undefined;
-  let password: string | undefined;
+  let body: unknown;
   try {
-    const body = (await req.json()) as {
-      email?: string;
-      password?: string;
-    };
-    email = body?.email;
-    password = body?.password;
+    body = await req.json();
   } catch {
     return NextResponse.json(
       { error: 'リクエストボディが不正です' },
@@ -28,12 +22,16 @@ export async function POST(req: Request) {
     );
   }
 
-  if (!email || !password) {
+  // **Zod でバリデーション**（メール形式・パスワード長を検証）
+  const parsed = CredentialsSchema.safeParse(body);
+  if (!parsed.success) {
     return NextResponse.json(
       { error: 'メールとパスワードが必要です' },
       { status: 400 },
     );
   }
+
+  const { email, password } = parsed.data;
 
   try {
     // ローカル環境のみモック認証を使用

--- a/app/api/auth/server-login/route.ts
+++ b/app/api/auth/server-login/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
     );
   }
 
-  // **Zod でバリデーション**（メール形式・パスワード長を検証）
+  // Zod でバリデーション（メール形式・パスワード長を検証）
   const parsed = CredentialsSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(


### PR DESCRIPTION
## 概要

issue #155 epic のサブIssue #154 を対応。`app/api/auth/server-login/route.ts` で `req.json()` が `try/catch` の外にあり、不正なJSONボディ受信時に統一エラー形式を返せず未制御の例外（500）が発生していた問題を修正。

Closes #154

## 変更内容

- `req.json()` を専用の `try/catch` で囲み、不正JSONボディ時に **400 + 統一エラー形式 `{ error }`** を返却
- ボディ検証を **`CredentialsSchema.safeParse`** に統一（型アサーション `as` を排除し、メール形式・パスワード長をランタイム検証）
  - 独立検証で「`as`キャストが既存 `CredentialsSchema` を迂回し『全APIでZodバリデーション必須』規約に違反」というHigh指摘を受け修正
  - `app/api/auth/refresh/route.ts` と同じ `safeParse` パターンに統一。未使用エクスポートだった `CredentialsSchema` を活用

## 受け入れ条件

- [x] 不正ボディ時に400で `{ error: "..." }` を返す
- [x] 統一エラー形式に準拠している

## 検証

- `npm run test:run`: 515テスト全パス
- `npm run build`: 成功
- `npm run format`: エラーなし

## 独立検証（code-review）

creator/verifier 分離のもと、security / api-design / code-quality の3観点で独立レビュー → High指摘修正後に再検証実施。

| 観点 | Critical | High | Medium | Low |
| ---- | -------- | ---- | ------ | --- |
| security-reviewer | 0 | 0 | 0(解消) | 3(既存) |
| api-design-reviewer | 0 | 0 | 0(解消) | - |
| code-quality-reviewer | 0 | 0 | 1 | 1(修正済) |

### 申し送り（Medium/Low / 本PRスコープ外）

- **Medium（code-quality）**: 新規の不正JSON/safeParse失敗パスにユニットテストなし。ただし本プロジェクトはAPIルートを統合テスト/E2Eでカバーする方針（route handler直接呼び出しのUT前例なし）のため、本PRでは追加せず申し送り。
- **Low（既存・スコープ外）**: 外側 catch の `{ error: 'Invalid credentials' }` + status 500 の意味論不整合、`AuthResponseSchema.parse` のスロー形式。いずれも #154 のスコープ外（別issue対応推奨）。

---

Generated by todoapp-backlog-loop

- item_id: issue:154
- creator: 直接実行（1ファイル局所修正）
- verifier verdict: conditional
- Critical/High: 0
- Medium/Low notes:
  - Medium: 新パスのUT未追加（プロジェクト方針によりAPIルートは統合/E2Eカバー・申し送り）
  - Low: コメント記法は修正済み。既存の500意味論・parse形式はスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)