### PR TITLE
feat: backlog-loop に事前承認バッチ・多重起動ロック・定期運用ガイドを追加

### DIFF
--- a/.agents/skills/todoapp-backlog-loop/SKILL.md
+++ b/.agents/skills/todoapp-backlog-loop/SKILL.md
@@ -9,6 +9,7 @@ description: |-
   引数:
     --dry-run: Phase 2 の選択結果を表示して終了。状態ファイル更新、実装、PR作成は行わない。
     --max-items=N: このサイクルで着手する最大件数。未指定時は 1、最大 2。
+    --unattended: 無人実行モード。実装開始承認を対話で求めず、承認が必要な項目は .claude/state/pending-approvals.md に登録してスキップする。loop-runner.sh からの起動時は常に付与される。
 
   使わない状況: 特定タスクの実装依頼、レビューのみ、PR作成のみ、課題発掘のみ。
 ---
@@ -22,7 +23,9 @@ description: |-
 
 「タスクが尽きるまで回し続ける」自律性は、スキル内部のループではなく外部 runner で実現する。
 `scripts/loop-runner.sh` が `LOOP_RESULT` を読み、最大サイクル数・サイクル間インターバル・
-コスト上限・ブランチ/クリーン検証・`BLOCKED` 即停止というサーキットブレーカー付きで次サイクルを起動する。
+コスト上限・ブランチ/クリーン検証・多重起動防止ロック・`BLOCKED` 即停止というサーキットブレーカー付きで
+次サイクルを起動する。runner はスキルを `--unattended` 付きで起動するため、実装開始承認は
+`.claude/state/pending-approvals.md` のバッチ承認（Phase 3 参照）に置き換わる。
 
 ```bash
 # 既定（最大5サイクル / 60s間隔）で自律実行
@@ -45,17 +48,19 @@ runner の制御だけを確認する場合は `scripts/test-loop-runner.sh` を
 - **creator と verifier を分離する**: 実装側の自己評価をPR条件にしない。`code-review` を独立ゲートとして使う。
 - **PR は Draft のみ**: Ready 化、merge、Issue close、ブランチ削除はしない。
 - **人間判断待ちは消化済み扱いにする**: inbox 登録済みの項目は、未処理 issue として再選択しない。
+- **無人モードでは承認を対話で求めない**: `--unattended` では orchestrator ルートの実装開始承認を `pending-approvals.md` への登録に置き換え、承認済み項目だけに着手する。
 - **上限を守る**: デフォルト着手 1 件、明示指定でも最大 2 件。verifier reject の修正依頼は 1 回だけ。
 
 ## State Files
 
 `.claude/state/` は gitignore 対象のローカル運用状態とする。存在しなければ `--dry-run` 以外で初期化する。
 
-| ファイル                            | 役割                                                    |
-| ----------------------------------- | ------------------------------------------------------- |
-| `.claude/state/loop-state.md`       | 前回実行、進行中、繰越キュー、処理済みID                |
-| `.claude/state/triage-inbox.md`     | 人間判断待ち。ここにある項目は自動選択から除外する      |
-| `.claude/state/verification-log.md` | verifier の判定ログ。pass / conditional / reject を記録 |
+| ファイル                             | 役割                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| `.claude/state/loop-state.md`        | 前回実行、進行中、繰越キュー、処理済みID                                  |
+| `.claude/state/triage-inbox.md`      | 人間判断待ち。ここにある項目は自動選択から除外する                        |
+| `.claude/state/verification-log.md`  | verifier の判定ログ。pass / conditional / reject を記録                   |
+| `.claude/state/pending-approvals.md` | 実装開始承認のバッチ承認キュー。無人モードの承認待ち / 承認済みプロンプト |
 
 状態に記録する `item_id` は安定した値にする。
 
@@ -83,7 +88,7 @@ Phase 6  State update and result signal
 
 1. `git status --short --untracked-files=all` を確認する。
 2. `git branch --show-current` が `develop-v2` であることを確認する。
-3. `.claude/state/` の 3 ファイルを読む。存在しない場合:
+3. `.claude/state/` の 4 ファイルを読む。存在しない場合:
    - `--dry-run` では作成せず「初回実行時に作成予定」と表示する。
    - 通常実行では末尾の初期フォーマットで作成する。
 4. `loop-state.md` の「進行中」を確認し、既存作業があれば新規候補より優先する。
@@ -151,6 +156,7 @@ gh run list --workflow "<workflowName>" \
 
 - `loop-state.md` の処理済み `item_id`
 - `triage-inbox.md` に未処理 `[ ]` として存在する `item_id`
+- `pending-approvals.md` に承認待ち `[ ]` として存在する `item_id`（承認済み `[x]` は優先選択の対象）
 - すでに open Draft PR が存在する同一 `item_id`
 - 最新 run で解消済みの CI failure
 
@@ -170,6 +176,9 @@ gh run list --workflow "<workflowName>" \
 - 既定: 1 件（PR）
 - `--max-items=N`: `N` 件（PR）を選択。ただし `N > 2` の場合は 2 にクランプする。
 - 進行中項目がある場合: 進行中を 1 件としてカウントし、新規選択枠は `max-items - 進行中件数` で決定する（例: 進行中1件 + `--max-items=2` → 新規選択は1件）
+
+選択の優先順位は ①進行中 ②`pending-approvals.md` の承認済み `[x]` 項目 ③新規 triage 候補 とする。
+承認済み項目は登録時のスコアとルートをそのまま使い、再スコアリングしない。
 
 選択結果を必ず表示する。
 
@@ -239,10 +248,25 @@ creator は実装・テスト・コミットまでを担当し、PR作成、stat
 
 1. `loop-creator` サブエージェント（`.claude/agents/loop-creator.md`）に委譲する。
 2. 入力は `references/subagent-contracts.md` の `Creator` 入力形式（`items` / `route` / `constraints` / `approved_prompt`）に従う。
-3. `route: todoapp-orchestrator` の場合、loop 親エージェントが creator 委譲前に実装開始承認を取る。`approved_prompt` には承認された実装開始プロンプト本文だけを入れ、実行するゲートやスキップするフェーズは `constraints` に入れる。
-4. 承認が得られた場合のみ、承認済み内容を `approved_prompt` として `loop-creator` に渡す。承認が得られない場合は creator を起動せず inbox に記録して `LOOP_RESULT: BLOCKED` または `STOP` とする。
+3. `route: todoapp-orchestrator` の場合、creator 委譲前に実装開始承認が必要。取得方法はモードで異なる（下記「実装開始承認の取得」）。`approved_prompt` には承認された実装開始プロンプト本文だけを入れ、実行するゲートやスキップするフェーズは `constraints` に入れる。
+4. 承認が得られた場合のみ、承認済み内容を `approved_prompt` として `loop-creator` に渡す。
 5. 複数 issue を1PRにまとめる場合は `items` に複数渡す。issue ごとに委譲を繰り返さない。これにより各 issue の実装差分がメインコンテキストに展開されるのを防ぐ。
 6. 戻り値は `creator_result` 形式で受け取る。
+
+#### 実装開始承認の取得（route: todoapp-orchestrator）
+
+**対話モード（既定）**: 親エージェントが実装開始プロンプトをユーザーに提示して承認を取る。
+承認が得られない場合は creator を起動せず、inbox に記録して `LOOP_RESULT: BLOCKED` または `STOP` とする。
+
+**無人モード（`--unattended`）**: 対話承認は行わず、`pending-approvals.md` のバッチ承認に置き換える。
+
+1. 対象項目の承認済み `[x]` エントリが `pending-approvals.md` にあれば、そのプロンプト本文を
+   `approved_prompt.prompt` に入れて委譲する。`approval_summary` にはバッチ承認である旨と承認登録日を書く。
+2. エントリがない、または未承認 `[ ]` の場合は実装しない。実装開始プロンプトを生成して
+   `pending-approvals.md` に承認待ちとして登録し、その項目をスキップして次の候補または Phase 6 へ進む。
+   承認待ち登録はそれ自体異常ではないため、これだけを理由に `BLOCKED` としない。
+3. 人間は `pending-approvals.md` の `- [ ] approved` を `- [x] approved` に変えて、次サイクル以降の
+   着手を承認する。プロンプト本文を修正してから承認してもよい。却下する場合は項目ブロックごと削除する。
 
 `loop-creator` は `route` に応じて `todoapp-orchestrator` または `fix-security-ci` を読み、Cross-Model Review と Draft PR Creation を実行せず Commit & Push まで担当する。これらの制約は `loop-creator` の定義に固定済みのため、呼び出し側で都度指定しなくてよい。
 
@@ -328,6 +352,9 @@ git pull --ff-only origin develop-v2
   - verifier reject / blocked
 - `verification-log.md`
   - pass / conditional / reject / blocked の全判定
+- `pending-approvals.md`
+  - 無人モードで新規登録した承認待ち項目
+  - 着手した承認済みエントリの削除
 
 最後に必ず次のいずれかを出力して終了する。
 
@@ -349,7 +376,7 @@ reason: 人間判断、環境異常、verifier実行不能、ブランチ復帰�
 
 `CONTINUE` を出せる条件:
 
-- 繰越キューに自動処理可能な候補がある
+- 繰越キューに自動処理可能な候補がある、または `pending-approvals.md` に承認済みで未着手の項目がある
 - inbox 未処理数が上限未満
 - 現在ブランチが `develop-v2`
 - worktree が clean
@@ -359,6 +386,7 @@ reason: 人間判断、環境異常、verifier実行不能、ブランチ復帰�
 
 - 候補がない
 - 候補はあるがすべて inbox 登録済み
+- 候補はあるがすべて承認待ちとして `pending-approvals.md` に登録済み
 - discovery のみ実行した
 - `--dry-run`
 
@@ -420,4 +448,25 @@ reason: 人間判断、環境異常、verifier実行不能、ブランチ復帰�
 
 | 日時 | item_id | ブランチ | creator | verdict | Critical/High | Medium/Low | PR  | 備考 |
 | ---- | ------- | -------- | ------- | ------- | ------------- | ---------- | --- | ---- |
+```
+
+**pending-approvals.md**
+
+```markdown
+# Pending Approvals
+
+無人サイクルが実装開始承認を求めている項目。`- [ ] approved` を `- [x] approved` にすると
+次サイクル以降に優先着手する。却下する場合は項目ブロックごと削除する。
+
+## <item_id>
+
+- [ ] approved
+- 登録日: YYYY-MM-DD
+- route: todoapp-orchestrator
+- score: <score>
+- source: <url>
+
+実装開始プロンプト:
+
+> <実装開始プロンプト本文（複数行可）>
 ```

--- a/.agents/skills/todoapp-backlog-loop/references/runbook.md
+++ b/.agents/skills/todoapp-backlog-loop/references/runbook.md
@@ -4,13 +4,14 @@
 
 ## まず見るもの
 
-| 状況                    | 確認先                              |
-| ----------------------- | ----------------------------------- |
-| runner が止まった       | `.claude/state/loop-runner.log`     |
-| 人間判断が必要          | `.claude/state/triage-inbox.md`     |
-| verifier の判定詳細     | `.claude/state/verification-log.md` |
-| 現在のキュー / 処理済み | `.claude/state/loop-state.md`       |
-| PR内容                  | GitHub Draft PR                     |
+| 状況                    | 確認先                               |
+| ----------------------- | ------------------------------------ |
+| runner が止まった       | `.claude/state/loop-runner.log`      |
+| 人間判断が必要          | `.claude/state/triage-inbox.md`      |
+| verifier の判定詳細     | `.claude/state/verification-log.md`  |
+| 実装開始承認の承認待ち  | `.claude/state/pending-approvals.md` |
+| 現在のキュー / 処理済み | `.claude/state/loop-state.md`        |
+| PR内容                  | GitHub Draft PR                      |
 
 ## `LOOP_RESULT` 別の対応
 
@@ -94,6 +95,17 @@ Critical / High 指摘が残っているためPRを作らない。
 2. 残ったブランチで修正するか、Issueとして切り直す。
 3. 必要なら `triage-inbox.md` の項目を更新する。
 
+### 多重起動ロック
+
+`loop-runner.sh` は `.claude/state/loop-runner.lock` で多重起動を防ぐ。
+別の runner が実行中の場合、後発は preflight で exit 1 する（cron の毎時起動が前回と重なっても安全）。
+
+対応:
+
+1. `cat .claude/state/loop-runner.lock/pid` で実行中 runner の PID を確認する。
+2. `ps -p <pid>` でプロセスが生きていれば、完了を待つ（多重起動させない）。
+3. プロセスが存在しない stale lock は次回起動時に runner が自動で奪取するため、手動削除は不要。
+
 ### claude 権限待ち / 非対話実行失敗
 
 既定の `LOOP_PERMISSION_MODE=acceptEdits` は安全側の設定。
@@ -104,6 +116,19 @@ Bashや外部コマンドで承認待ちが出る場合がある。
 - まず手動で1サイクル実行して、必要な承認範囲を確認する。
 - 無人運用する場合だけ `LOOP_EXTRA_ARGS` で許可ツールを絞って指定する。
 - 全権限バイパスを常用しない。
+
+## 実装開始承認バッチ（pending-approvals）
+
+無人運用（`--unattended`、runner 起動時は常時）では、`todoapp-orchestrator` ルートの項目は
+人間の事前承認がないと実装されない。承認待ちは `.claude/state/pending-approvals.md` に溜まる。
+
+1. `.claude/state/pending-approvals.md` を開く。
+2. 各項目の実装開始プロンプトを確認する。必要なら本文を修正する。
+3. 着手してよい項目の `- [ ] approved` を `- [x] approved` に変える。
+4. 却下する項目はブロックごと削除する（理由を残す場合は `triage-inbox.md` に記録する）。
+5. 次の runner 起動時、承認済み項目が新規候補より優先して着手される。
+
+`fix-security-ci` ルートは事前承認なしで自動処理される。
 
 ## Draft PRが作られた後
 
@@ -132,5 +157,6 @@ runner の制御だけ確認する。
 - `test-loop-runner.sh` が通る
 - `--dry-run` が通る
 - `triage-inbox.md` の未処理が溜まりすぎていない
+- `pending-approvals.md` の承認待ちが溜まりすぎていない
 - Draft PR を処理できる人間のレビュー枠がある
 - `LOOP_MAX_CYCLES` と `LOOP_MAX_BUDGET_USD` が過剰でない

--- a/.agents/skills/todoapp-backlog-loop/references/runner.md
+++ b/.agents/skills/todoapp-backlog-loop/references/runner.md
@@ -27,16 +27,17 @@
 
 ## セーフガード（暴走防止）
 
-| ガード                 | 環境変数               | 既定値        | 役割                                  |
-| ---------------------- | ---------------------- | ------------- | ------------------------------------- |
-| 最大サイクル数         | `LOOP_MAX_CYCLES`      | `5`           | ループ全体のハードキャップ            |
-| サイクル間インターバル | `LOOP_INTERVAL`        | `60`（秒）    | レート制限 / orchestration tax の抑制 |
-| 1 サイクル実時間上限   | `LOOP_CYCLE_TIMEOUT`   | `1800`（秒）  | ハング検知（watchdog で強制終了）     |
-| 1 サイクルコスト上限   | `LOOP_MAX_BUDGET_USD`  | `5`（USD）    | claude `--max-budget-usd` に渡す      |
-| 着手件数               | `LOOP_MAX_ITEMS`       | `1`           | スキル `--max-items` に渡す（最大 2） |
-| 動作ブランチ           | `LOOP_BRANCH`          | `develop-v2`  | サイクル毎に検証。違えば停止          |
-| クリーン検証           | （常時）               | -             | サイクル毎に dirty なら停止           |
-| 権限モード             | `LOOP_PERMISSION_MODE` | `acceptEdits` | claude `--permission-mode` に渡す     |
+| ガード                 | 環境変数               | 既定値                           | 役割                                                                    |
+| ---------------------- | ---------------------- | -------------------------------- | ----------------------------------------------------------------------- |
+| 最大サイクル数         | `LOOP_MAX_CYCLES`      | `5`                              | ループ全体のハードキャップ                                              |
+| サイクル間インターバル | `LOOP_INTERVAL`        | `60`（秒）                       | レート制限 / orchestration tax の抑制                                   |
+| 1 サイクル実時間上限   | `LOOP_CYCLE_TIMEOUT`   | `1800`（秒）                     | ハング検知（watchdog で強制終了）                                       |
+| 1 サイクルコスト上限   | `LOOP_MAX_BUDGET_USD`  | `5`（USD）                       | claude `--max-budget-usd` に渡す                                        |
+| 着手件数               | `LOOP_MAX_ITEMS`       | `1`                              | スキル `--max-items` に渡す（最大 2）                                   |
+| 動作ブランチ           | `LOOP_BRANCH`          | `develop-v2`                     | サイクル毎に検証。違えば停止                                            |
+| クリーン検証           | （常時）               | -                                | サイクル毎に dirty なら停止                                             |
+| 多重起動防止ロック     | `LOOP_LOCK_DIR`        | `.claude/state/loop-runner.lock` | 同時実行を 1 つに制限。別 runner 実行中は exit 1、stale lock は自動奪取 |
+| 権限モード             | `LOOP_PERMISSION_MODE` | `acceptEdits`                    | claude `--permission-mode` に渡す                                       |
 
 加えて runner は次を行う。
 
@@ -44,6 +45,13 @@
   残していたら停止する（多層防御）。
 - `SIGINT` / `SIGTERM` を受けたら、現在のサイクル完了後に安全に停止する。
 - 全サイクルの結果・コストを `.claude/state/loop-runner.log` に追記する。
+
+## 無人モードと実装開始承認（バッチ承認）
+
+runner はスキルを `--unattended` 付きで起動する。`todoapp-orchestrator` ルートの項目は
+`.claude/state/pending-approvals.md` に人間が事前承認（`[x]`）したプロンプトがある場合のみ実装され、
+未承認の項目は同ファイルに承認待ちとして登録されてスキップされる（`BLOCKED` にはならない）。
+`fix-security-ci` ルートは事前承認なしで自動処理される。承認手順は `references/runbook.md` を参照。
 
 ## 権限モードについて（重要）
 
@@ -78,11 +86,27 @@ LOOP_MAX_CYCLES=3 LOOP_INTERVAL=120 .agents/skills/todoapp-backlog-loop/scripts/
 | `2`    | `BLOCKED`、タイムアウト、claude エラー終了  |
 | `3`    | `LOOP_RESULT` を解釈不能（契約違反）        |
 
-## cron 運用（任意）
+## 定期運用
 
-無人で定期起動する場合も、runner 自体が 1 起動で完結するため cron と二重には回らない。
+### ローカル cron
+
+runner 自体が 1 起動で完結する。前回起動がまだ実行中の場合でも、`.claude/state/loop-runner.lock` の
+多重起動防止ロックにより後発は exit 1 で即終了するため、二重には回らない。
 
 ```cron
 # 平日 9-18 時に 1 時間おきに 1 起動（各起動は最大 5 サイクルで自己完結）
 0 9-18 * * 1-5 cd /path/to/todoApp-next && LOOP_MAX_CYCLES=5 .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh >> .claude/state/loop-cron.log 2>&1
 ```
+
+ローカル cron はマシンが起動している間しか回らない点に注意する。
+
+### クラウドスケジューリング（Routines / Claude Code on the web）
+
+Claude Code のスケジュール実行（Routines 等）は Anthropic のクラウド上で動くため、
+ローカルマシンの稼働に依存しない。ただし本スキルの `.claude/state/` は gitignore された
+ローカル状態であり、エフェメラルなクラウドセッションでは実行間で保持されない。
+
+- **現状のスキルはローカル runner を前提とする。** クラウドで定期実行する場合は、state を
+  リモートに永続化する再設計（state 専用ブランチへのコミット、GitHub Issue / ラベルを
+  state として使う等）が先に必要。
+- それまでの運用方針: ローカルでは本 runner + cron、クラウドでの定期実行は非対応と扱う。

--- a/.agents/skills/todoapp-backlog-loop/references/runner.md
+++ b/.agents/skills/todoapp-backlog-loop/references/runner.md
@@ -95,7 +95,7 @@ runner 自体が 1 起動で完結する。前回起動がまだ実行中の場�
 
 ```cron
 # 平日 9-18 時に 1 時間おきに 1 起動（各起動は最大 5 サイクルで自己完結）
-0 9-18 * * 1-5 cd /path/to/todoApp-next && LOOP_MAX_CYCLES=5 .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh >> .claude/state/loop-cron.log 2>&1
+0 9-18 * * 1-5 cd /path/to/todoApp-next && mkdir -p .claude/state && LOOP_MAX_CYCLES=5 .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh >> .claude/state/loop-cron.log 2>&1
 ```
 
 ローカル cron はマシンが起動している間しか回らない点に注意する。

--- a/.agents/skills/todoapp-backlog-loop/references/state-templates.md
+++ b/.agents/skills/todoapp-backlog-loop/references/state-templates.md
@@ -52,8 +52,30 @@
 | ---- | ------- | -------- | ------- | ------- | ------------- | ---------- | --- | ---- |
 ```
 
+## `.claude/state/pending-approvals.md`
+
+```markdown
+# Pending Approvals
+
+無人サイクルが実装開始承認を求めている項目。`- [ ] approved` を `- [x] approved` にすると
+次サイクル以降に優先着手する。却下する場合は項目ブロックごと削除する。
+
+## <item_id>
+
+- [ ] approved
+- 登録日: YYYY-MM-DD
+- route: todoapp-orchestrator
+- score: <score>
+- source: <url>
+
+実装開始プロンプト:
+
+> <実装開始プロンプト本文（複数行可）>
+```
+
 ## 運用メモ
 
 - `item_id` は `issue:156`、`ci:security-review:123456` のように安定した値にする。
 - `triage-inbox.md` に未処理 `[ ]` としてある item は、自動選択から除外する。
+- `pending-approvals.md` の承認待ち `[ ]` item は自動選択から除外し、承認済み `[x]` item は新規候補より優先して着手する。
 - Obsidian の会話履歴は詳細ログとして扱い、この state は次サイクル用の短い運用台帳として扱う。

--- a/.agents/skills/todoapp-backlog-loop/references/subagent-contracts.md
+++ b/.agents/skills/todoapp-backlog-loop/references/subagent-contracts.md
@@ -85,7 +85,7 @@ route: '<todoapp-orchestrator|fix-security-ci>'
 approved_prompt: # route が todoapp-orchestrator の場合は必須
   approved_by: 'loop-parent'
   approved_at: '<ISO-8601>'
-  approval_summary: 'loop 実行前にユーザーが承認した実装開始内容'
+  approval_summary: '対話承認または pending-approvals.md のバッチ承認で承認された実装開始内容'
   prompt: |
     <ユーザーに提示して承認された実装開始プロンプト>
 constraints:
@@ -95,7 +95,10 @@ constraints:
   - '.env / secrets は読まない'
 ```
 
-`route: todoapp-orchestrator` では、親 loop が creator 委譲前に `approved_prompt.prompt` の本文をユーザーへ提示して承認を取る。
+`route: todoapp-orchestrator` では、親 loop が creator 委譲前に実装開始承認を取る。対話モードでは
+`approved_prompt.prompt` の本文をユーザーへ提示して承認を取り、無人モード（`--unattended`）では
+`.claude/state/pending-approvals.md` で人間が事前承認（`[x]`）したプロンプト本文を使う（バッチ承認）。
+未承認の項目は委譲せず、親が承認待ちとして `pending-approvals.md` に登録する。
 `loop-creator` と `todoapp-orchestrator` はこの承認済みプロンプトを Phase 3a の指示書承認ゲートの入力として扱い、同じ内容の再承認を要求しない。
 ただし、承認済みプロンプトに含まれないスコープ追加、API / Firestore / Auth 変更の新規発見、テスト skip、危険なコマンド切替が必要になった場合は `status=needs_human` で親に戻す。
 

--- a/.agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh
+++ b/.agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh
@@ -87,7 +87,10 @@ acquire_lock() {
     exit 1
   fi
   warn "stale lock を検出しました（pid=${other_pid:-不明}）。ロックを取得し直します。"
-  rm -rf "$LOOP_LOCK_DIR"
+  local stale_dir="${LOOP_LOCK_DIR}.stale.$$"
+  if mv "$LOOP_LOCK_DIR" "$stale_dir" 2>/dev/null; then
+    rm -rf "$stale_dir"
+  fi
   if ! mkdir "$LOOP_LOCK_DIR" 2>/dev/null; then
     err "ロックを取得できませんでした: ${LOOP_LOCK_DIR}"
     exit 1

--- a/.agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh
+++ b/.agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #
 # これにより PR #156 が持っていた「タスクが尽きるまで自律的に回り続ける」性質を、
 # 暴走防止のサーキットブレーカー（最大サイクル数・サイクル間インターバル・コスト上限・
-# ブランチ/クリーン検証・BLOCKED 即停止）付きで取り戻す。
+# ブランチ/クリーン検証・多重起動防止ロック・BLOCKED 即停止）付きで取り戻す。
 #
 # 使い方:
 #   .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh
@@ -30,6 +30,7 @@ LOOP_MAX_BUDGET_USD="${LOOP_MAX_BUDGET_USD:-5}"  # 1 サイクルあたりの cl
 LOOP_PERMISSION_MODE="${LOOP_PERMISSION_MODE:-acceptEdits}" # claude の権限モード
 LOOP_MODEL="${LOOP_MODEL:-}"                      # 空ならセッション既定モデル
 LOOP_LOG="${LOOP_LOG:-.claude/state/loop-runner.log}"
+LOOP_LOCK_DIR="${LOOP_LOCK_DIR:-.claude/state/loop-runner.lock}" # 多重起動防止ロック（ディレクトリ）
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 LOOP_EXTRA_ARGS="${LOOP_EXTRA_ARGS:-}"           # claude へ追加で渡す引数（例: 権限の allowlist）
 
@@ -65,6 +66,42 @@ on_interrupt() {
   warn "中断シグナルを受信。現在のサイクル完了後に停止します。"
 }
 trap on_interrupt INT TERM
+
+# --- 多重起動防止ロック ---------------------------------------------------------
+# cron の毎時起動などで前回の runner がまだ実行中の場合に二重に回さないためのロック。
+# mkdir はアトミックで macOS でも動く。プロセスが消えた stale lock は自動で奪取する。
+
+LOCK_ACQUIRED=false
+
+acquire_lock() {
+  mkdir -p "$(dirname "$LOOP_LOCK_DIR")"
+  if mkdir "$LOOP_LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' "$$" > "$LOOP_LOCK_DIR/pid"
+    LOCK_ACQUIRED=true
+    return 0
+  fi
+  local other_pid
+  other_pid="$(cat "$LOOP_LOCK_DIR/pid" 2>/dev/null || true)"
+  if [[ -n "$other_pid" ]] && kill -0 "$other_pid" 2>/dev/null; then
+    err "別の runner が実行中です（pid=${other_pid}, lock=${LOOP_LOCK_DIR}）。多重起動を防ぐため停止します。"
+    exit 1
+  fi
+  warn "stale lock を検出しました（pid=${other_pid:-不明}）。ロックを取得し直します。"
+  rm -rf "$LOOP_LOCK_DIR"
+  if ! mkdir "$LOOP_LOCK_DIR" 2>/dev/null; then
+    err "ロックを取得できませんでした: ${LOOP_LOCK_DIR}"
+    exit 1
+  fi
+  printf '%s\n' "$$" > "$LOOP_LOCK_DIR/pid"
+  LOCK_ACQUIRED=true
+}
+
+release_lock() {
+  if $LOCK_ACQUIRED; then
+    rm -rf "$LOOP_LOCK_DIR"
+  fi
+}
+trap release_lock EXIT
 
 # --- ユーティリティ -----------------------------------------------------------
 
@@ -112,6 +149,7 @@ verify_repo_state() {
 # --- preflight ----------------------------------------------------------------
 
 mkdir -p "$(dirname "$LOOP_LOG")"
+acquire_lock
 
 if ! [[ "$LOOP_MAX_ITEMS" =~ ^[0-9]+$ ]]; then
   err "LOOP_MAX_ITEMS は数値で指定してください（現在: ${LOOP_MAX_ITEMS}）。"
@@ -147,7 +185,7 @@ ok "preflight 通過。"
 # --- メインループ -------------------------------------------------------------
 
 cycle=0
-prompt="/todoapp-backlog-loop --max-items=${LOOP_MAX_ITEMS}"
+prompt="/todoapp-backlog-loop --max-items=${LOOP_MAX_ITEMS} --unattended"
 $DRY_RUN && prompt="/todoapp-backlog-loop --dry-run"
 
 while true; do

--- a/.agents/skills/todoapp-backlog-loop/scripts/test-loop-runner.sh
+++ b/.agents/skills/todoapp-backlog-loop/scripts/test-loop-runner.sh
@@ -169,6 +169,82 @@ run_case "CONTINUE then STOP exits 0" "continue_then_stop" 0
 run_case "CONTINUE hits max cycles exits 0" "continue_forever" 0
 run_case "dirty tree fails preflight" "stop" 1 true
 
+# --- 多重起動防止ロックのテスト -------------------------------------------------
+
+run_lock_case_active() {
+  local name="active lock blocks second runner exits 1"
+  setup_case "$name" "stop"
+  local repo="$CASE_REPO"
+
+  # 生きている PID（このテストシェル自身）でロックを保持している状況を作る
+  mkdir -p "$repo/.claude/state/loop-runner.lock"
+  printf '%s\n' "$$" > "$repo/.claude/state/loop-runner.lock/pid"
+
+  set +e
+  local output_file="$TMP_ROOT/lock_active.out"
+  (
+    cd "$repo"
+    LOOP_BRANCH=develop-v2 \
+      LOOP_MAX_CYCLES=1 \
+      LOOP_INTERVAL=0 \
+      LOOP_CYCLE_TIMEOUT=30 \
+      LOOP_LOG=.claude/state/test-loop-runner.log \
+      .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh >"$output_file" 2>&1
+  )
+  local rc=$?
+  set -e
+
+  assert_eq "$name" 1 "$rc"
+  if [[ "$rc" -ne 1 ]]; then
+    sed -n '1,160p' "$output_file" >&2
+  fi
+  local lock_state="absent"
+  [[ -d "$repo/.claude/state/loop-runner.lock" ]] && lock_state="present"
+  assert_eq "active lock is not removed by loser" "present" "$lock_state"
+  cleanup
+  TMP_ROOT=""
+}
+
+run_lock_case_stale() {
+  local name="stale lock is taken over exits 0"
+  setup_case "$name" "stop"
+  local repo="$CASE_REPO"
+
+  # 既に終了した PID で stale lock を作る
+  sleep 0 &
+  local dead_pid=$!
+  wait "$dead_pid" 2>/dev/null || true
+  mkdir -p "$repo/.claude/state/loop-runner.lock"
+  printf '%s\n' "$dead_pid" > "$repo/.claude/state/loop-runner.lock/pid"
+
+  set +e
+  local output_file="$TMP_ROOT/lock_stale.out"
+  (
+    cd "$repo"
+    LOOP_BRANCH=develop-v2 \
+      LOOP_MAX_CYCLES=1 \
+      LOOP_INTERVAL=0 \
+      LOOP_CYCLE_TIMEOUT=30 \
+      LOOP_LOG=.claude/state/test-loop-runner.log \
+      .agents/skills/todoapp-backlog-loop/scripts/loop-runner.sh >"$output_file" 2>&1
+  )
+  local rc=$?
+  set -e
+
+  assert_eq "$name" 0 "$rc"
+  if [[ "$rc" -ne 0 ]]; then
+    sed -n '1,160p' "$output_file" >&2
+  fi
+  local lock_state="absent"
+  [[ -d "$repo/.claude/state/loop-runner.lock" ]] && lock_state="present"
+  assert_eq "lock released after run" "absent" "$lock_state"
+  cleanup
+  TMP_ROOT=""
+}
+
+run_lock_case_active
+run_lock_case_stale
+
 echo "passed: $PASS_COUNT, failed: $FAIL_COUNT"
 if [[ "$FAIL_COUNT" -ne 0 ]]; then
   exit 1


### PR DESCRIPTION
# プルリクエストテンプレート

## 概要

`todoapp-backlog-loop` スキルを Claude ブログ「[Getting started with loops](https://claude.com/blog/getting-started-with-loops)」の Loop Engineering 指針と照合して評価した結果、挙がった3つの改善点（無人運用と承認ゲートの矛盾、cron 多重起動の防止、クラウドスケジューリングと state 永続化の未整理）を解消します。

## 主な変更点

**1. 事前承認バッチ方式（`--unattended` + `pending-approvals.md`）**

- スキルに `--unattended` フラグと4つ目の state ファイル `.claude/state/pending-approvals.md` を追加。
- 無人サイクルでは orchestrator ルートの実装開始承認を対話で求めず、生成した実装開始プロンプトを承認待ち `[ ]` として登録してスキップする（これだけを理由に `BLOCKED` としない）。
- 人間が `- [x] approved` に変えてバッチ承認した項目は、次サイクルで新規候補より優先して着手する（優先順位: ①進行中 ②承認済み ③新規候補）。
- 承認待ち項目の再選択除外、CONTINUE/STOP 条件、Phase 6 の state 更新、初期テンプレート、`subagent-contracts.md`（承認の出所2系統）、`runbook.md`（承認手順）も整合するよう更新。`fix-security-ci` ルートは従来どおり事前承認なしで自動処理。

**2. 多重起動防止ロック（`loop-runner.sh`）**

- `mkdir` + PID ファイル方式のポータブルなロック（`LOOP_LOCK_DIR`、既定 `.claude/state/loop-runner.lock`）を preflight に追加。別 runner 実行中は exit 1、プロセスが消えた stale lock は自動奪取、EXIT trap で解放。
- cron の毎時起動が長時間実行中の前回起動と重なっても二重に回らない。
- runner がスキルを `--unattended` 付きで起動するよう変更。
- `test-loop-runner.sh` にロックのテスト4件（生存ロックで後発 exit 1 / 敗者が他者ロックを消さない / stale lock 奪取 / 実行後の解放）を追加。

**3. 定期運用ガイドの併記（`runner.md`）**

- cron 節を「定期運用」に拡張し、ローカル cron とクラウドスケジューリング（Routines / Claude Code on the web）を併記。
- `.claude/state/` が gitignore されたローカル状態でありクラウドのエフェメラルセッションでは永続しない制約と、クラウド定期実行には state のリモート永続化（state 専用ブランチ、GitHub Issue/ラベルの state 化など）の再設計が先に必要である方針を明記。

## 関連 Issue

なし（Loop Engineering 評価からの改善）

## スクリーンショット（必要に応じて）

UI 変更なし

## 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 📝 ドキュメント更新 (Documentation)
- [x] 🧪 テスト追加・修正 (Tests)
- [x] 🔧 設定・ツール変更 (Configuration/Tools)

## テスト

- [x] `test-loop-runner.sh` 全11ケース通過（既存7＋新規4）
- [x] `bash -n` による `loop-runner.sh` / `test-loop-runner.sh` の構文チェック
- [x] Lint/Format 実行済み（変更 Markdown に prettier 適用）
- [ ] ユニットテスト（`npm run test`）: アプリコードに変更がないため対象外
- [ ] 統合テスト / E2E テスト: アプリコードに変更がないため対象外

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 関連するドキュメントを更新した（SKILL.md / runner.md / runbook.md / state-templates.md / subagent-contracts.md）
- [x] 破壊的変更がある場合、適切に文書化した（破壊的変更なし。`--unattended` 未指定の対話モードは従来挙動のまま）
- [x] セキュリティ上の問題がないことを確認した（Draft PR のみ・委譲禁止リスト等の既存安全装置は不変）
- [x] 既存のテストが通ることを確認した
- [x] コーディングガイドラインに従っている
- [x] 機密情報や API キーが含まれていない
- [x] PR の説明が分かりやすく書かれている

## 追加の注意事項

- `.claude/skills/todoapp-backlog-loop` は `.agents/skills/todoapp-backlog-loop` へのシンボリックリンクのため、変更は `.agents/` 側の7ファイルに現れます。
- 作業中に判明した別件: `.claude/settings.json` の PreToolUse フックが `/bin/sh`（dash）環境で `set -o pipefail` 非対応により常に失敗し、リモート実行環境では Edit/Write が全ブロックされます。本 PR のスコープ外のため未修正ですが、dash 互換化（`set -o pipefail` の除去または `bash -c` ラップ）を別途おすすめします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8KcdHukhVd49e7vxw8vCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8KcdHukhVd49e7vxw8vCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 無人実行モードを追加し、事前承認（承認待ち管理）に基づいて作業を優先して進行できるようになりました。
* **Bug Fixes**
  * 承認待ちの項目を自動選択から除外し、未承認の着手を防ぎます。
  * 期限切れの多重起動ロックでも正常に引き継いで実行できるよう改善しました。
* **Documentation**
  * 手順・確認観点、承認待ちの運用方法、多重起動防止の停止理由を拡充しました。
* **Tests**
  * 多重起動ロック挙動の検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->